### PR TITLE
chore: remove hot reload references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# Agent Handbook for `discord-bot-framework`
+
+Welcome! This repository houses a modular Discord bot built on top of Hikari (gateway client), Lightbulb (command router), and Miru (component UI). Plugins drive all user-facing features, while shared services cover persistence, permissions, and event orchestration. Use this guide to stay aligned with the existing architecture.
+
+## 1. High-level picture
+1. `python -m bot` or `bot/cli.py run` constructs `bot.core.bot.DiscordBot`.
+2. `DiscordBot` wires together the Hikari gateway client, the Lightbulb command client, Miru UI, the async SQLAlchemy database manager, the permission subsystem, the plugin loader, the event system, and the custom prefix command handler.
+3. During startup `_initialize_systems()` creates tables, seeds default permissions, loads enabled plugins from `config.settings.settings.enabled_plugins`, then announces readiness through the internal `EventSystem`.
+4. Plugins register slash and prefix commands via the unified decorators in `bot.plugins.commands`, hook into events with `bot.core.event_system.event_listener`, and use helpers from `bot.plugins.base.BasePlugin` for embeds, logging, and persistence.
+
+## 2. Repository tour
+- `bot/__main__.py` – CLI-friendly entry point that configures logging and starts the gateway bot.
+- `bot/cli.py` – Typer-based CLI for running the bot, scaffolding projects, and managing DB tables.
+- `bot/core/` – Runtime wiring: `bot.py`, plugin loader, event bus, prefix message handler, and Discord permission utilities.
+- `bot/plugins/` – Framework primitives (`BasePlugin`, command registry, argument parsing, decorators).
+- `bot/database/` – Async SQLAlchemy manager plus ORM models for guilds, users, permission grants, command analytics, and the music queue/session tables.
+- `bot/permissions/` – Role-based permission manager and decorators (`requires_permission`, `requires_role`, `requires_guild_owner`, `requires_bot_permissions`).
+- `bot/middleware/` – Optional event middleware for logging, analytics, and error collection (attach via `EventSystem.add_middleware`).
+- `plugins/` – First-party plugin packages (`admin`, `fun`, `help`, `moderation`, `utility`, `music`) plus authoring guide in `plugins/README.md`.
+- `config/settings.py` – Pydantic settings model; exposes a singleton `settings` used across the app. Environment variables live in `.env`.
+- `tests/` – Pytest suite organised by domain (`tests/unit/bot/...` for framework, `tests/unit/plugins/<name>/...` for plugin coverage). Fixtures reside in `tests/conftest.py`.
+
+## 3. Runtime building blocks
+- **DiscordBot (`bot/core/bot.py`)**: Handles lifecycle events, subscribes to gateway events, initializes subsystems, forwards guild messages to the prefix handler, and exposes helpers such as `add_startup_task` and `get_guild_prefix`.
+- **Plugin loader (`bot/core/plugin_loader.py`)**: Discovers packages from `settings.plugin_directories`, reads `PLUGIN_METADATA`, instantiates subclasses of `bot.plugins.base.BasePlugin` (or a `setup` factory), applies dependency checks, and manages plugin load/unload lifecycles.
+- **Event system (`bot/core/event_system.py`)**: Publish/subscribe bus with async middleware hooks. Use `@event_listener("event_name")` within plugins to auto-register handlers, and `bot.event_system.add_middleware(...)` for cross-cutting concerns.
+- **Prefix commands (`bot/core/message_handler.py`)**: `MessageCommandHandler` inspects messages starting with `settings.bot_prefix`, creates a `PrefixContext`, enforces permission nodes when provided, and delegates argument parsing to `bot.plugins.commands.ArgumentParserFactory`.
+- **Permissions (`bot/permissions/manager.py`)**: `PermissionManager` caches granted nodes per guild role, seeds defaults (admin/moderation/utility/fun/music), applies hierarchy rules (e.g., `admin.*` grants everything), and backs the Lightbulb decorators in `bot/permissions/decorators.py`.
+- **Database (`bot/database/manager.py` & `bot/database/models.py`)**: Async engine selection for SQLite or PostgreSQL. Always interact via `async with db_manager.session():` and commit inside the context. Models cover guild configuration, users, role permissions, command usage, plugin settings, and music queues/sessions.
+
+## 4. Plugin authoring & extension
+- Package layout: `plugins/<slug>/__init__.py` exports the plugin class (or `setup` factory) and declares `PLUGIN_METADATA`; the implementation module(s) subclass `BasePlugin`.
+- `BasePlugin` features:
+  - Lifecycle hooks `on_load` / `on_unload` automatically register/unregister slash and prefix commands discovered via the decorators in `bot.plugins.commands`.
+  - Helpers: `create_embed`, `smart_respond` (handles ephemeral logic), `log_command_usage`, plus per-guild settings helpers (`get_setting`, `set_setting`, enable/disable toggles).
+  - Automatically tracks event listeners flagged with `@event_listener` and registers them against the shared `EventSystem`.
+- Unified command decorator (`bot/plugins/commands/decorators.py::command`): define `name`, `description`, optional aliases, `permission_node`, and a shared `arguments` list of `CommandArgument`. Slash commands receive Lightbulb option descriptors; prefix commands are wrapped with `PrefixCommand` instances and parsed via `ArgumentParserFactory` (string, int, bool, user, channel, role, mentionable).
+- Respect permission nodes: declare required nodes in `PLUGIN_METADATA["permissions"]`, guard handlers with `permission_node="plugin.node"` or manual decorator stacking, and update tests if access rules change.
+- For plugins needing persistence, use the provided database models or introduce new ORM entities in `bot/database/models.py` (with accompanying migrations/tests). Leverage `BasePlugin.get_setting`/`set_setting` for lightweight per-guild configuration.
+- Music plugin specifics live in `plugins/music/`; it integrates Lavalink (see `config.settings` for connection fields) and persists queue/session state. Install optional extras (`uv sync --extra music`) when modifying those components.
+
+## 5. Configuration & environment
+- Settings are centrally provided by `config.settings.settings` (Pydantic). Modify defaults thoughtfully and document new fields in `README.md` or `.env.example`.
+- Development vs production: the CLI `run --dev` flag sets `ENVIRONMENT=development`. Docker workflows are defined in `docker-compose.dev.yml` / `docker-compose.yml`.
+- Secrets (`DISCORD_TOKEN`, etc.) should be referenced via environment variables; never hard-code tokens.
+
+## 6. Coding standards & tooling
+- Target **Python 3.11+** with comprehensive type hints. Maintain async/await boundaries—avoid blocking IO in event handlers or commands.
+- Formatting: Black with **135 character** max line length (`pyproject.toml`). Run `uv run black .` when needed.
+- Linting: Ruff enforces error codes `E,F,W,I,N,UP,S,B,A,C4,T20`. Execute `uv run ruff check .` (tests are excluded by default).
+- Logging: use `logging.getLogger(__name__)`; avoid `print`. Follow existing message styles (info for lifecycle, debug for verbose traces, warning/error for failures).
+- Discord interactions: prefer rich embeds via `BasePlugin.create_embed` and respond through `BasePlugin.smart_respond` to unify slash/prefix behaviour.
+- Permission/DB helpers already handle caching and error logging; prefer extending them over duplicating logic.
+
+## 7. Testing expectations
+- Unit tests live under `tests/unit/bot/` (core) and `tests/unit/plugins/<plugin>/`. Mirror new behaviour with corresponding tests.
+- Default coverage threshold is **70%** (`run_tests.py`, `pyproject.toml`). Running `uv run pytest` (or `make test`) with coverage is the baseline; add `--cov` flags for focused runs (`uv run pytest tests/unit/plugins/admin --cov=plugins/admin`).
+- `python run_tests.py --separate-coverage` executes suites per plugin and generates HTML reports in `htmlcov/`.
+- Async tests rely on `pytest-asyncio` (`asyncio_mode = auto`). Use provided fixtures in `tests/conftest.py` to stub Discord objects, database sessions, and plugin instances.
+- When altering CLI/database tooling, add regression coverage under `tests/unit/bot/test_cli.py` or similar.
+
+## 8. Helpful commands
+- `python -m bot` – start the gateway bot (use `--dev` for development mode).
+- `python -m bot.cli` – inspect CLI commands (`run`, `plugins`, `db`, `init`).
+- `make help` – discover Make targets (`make lint`, `make format`, `make test`, `make install-dev`, etc.).
+- `uv run pytest` – primary test command; `uv sync --extra dev` installs dev dependencies.
+- `make db-create` / `make db-reset` – manage schema during development (uses async SQLAlchemy).
+
+## 9. Collaboration tips
+- Keep plugins decoupled: communicate via the `EventSystem` or shared database tables instead of direct cross-plugin imports when possible.
+- Clean up external resources (aiohttp sessions, background tasks) inside `on_unload` to avoid resource leaks and ensure stable unloads.
+- Update documentation (`README.md`, plugin-specific READMEs) whenever commands, permissions, or environment variables change.
+- If new conventions emerge for a subdirectory, add a nested `AGENTS.md` with scoped instructions so future agents inherit the context.
+
+Happy building, and may your bots be ever responsive! 🤖

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ bot-run: env-validate ## Run the bot in production mode
 	@echo "$(BOLD)$(BLUE)Starting bot in production mode...$(RESET)"
 	$(UV_RUN) $(PYTHON) -m $(BOT_MODULE)
 
-bot-dev: env-validate ## Run the bot in development mode with hot reload
+bot-dev: env-validate ## Run the bot in development mode
 	@echo "$(BOLD)$(BLUE)Starting bot in development mode...$(RESET)"
 	$(UV_RUN) $(PYTHON) -m $(BOT_MODULE) --dev
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A modular Discord bot built with the Hikari framework, featuring a plugin system
 
 ## Features
 
-- 🔌 **Plugin System** - Modular architecture with hot reload support
+- 🔌 **Plugin System** - Modular architecture with dynamic plugin loading
 - 🔒 **RBAC Permissions** - Role-based access control using Discord roles
 - 🗄️ **Database Support** - SQLite for development, PostgreSQL for production
 - 🐳 **Docker Ready** - Development and production Docker configurations
@@ -45,7 +45,7 @@ python -m bot.cli db create
 
 5. Run the bot:
 ```bash
-python -m bot.cli run --dev  # Development mode with hot reload
+python -m bot.cli run --dev  # Development mode with development defaults
 # or
 python -m bot.cli run        # Production mode
 ```
@@ -53,7 +53,7 @@ python -m bot.cli run        # Production mode
 ### Docker Development
 
 ```bash
-# Development with hot reload
+# Development environment
 docker-compose up bot-dev
 
 # Production with PostgreSQL

--- a/bot/cli.py
+++ b/bot/cli.py
@@ -33,7 +33,6 @@ def run(
         import os
 
         os.environ["ENVIRONMENT"] = "development"
-        os.environ["HOT_RELOAD"] = "true"
 
     if log_level:
         import os

--- a/tests/unit/bot/test_cli.py
+++ b/tests/unit/bot/test_cli.py
@@ -71,7 +71,6 @@ class TestCLICommands:
 
         assert result.exit_code == 0
         assert os.environ.get("ENVIRONMENT") == "development"
-        assert os.environ.get("HOT_RELOAD") == "true"
         mock_discord_bot.assert_called_once()
         mock_bot_instance.run.assert_called_once()
 
@@ -258,15 +257,11 @@ class TestEnvironmentVariables:
         # Clear environment variables first
         if "ENVIRONMENT" in os.environ:
             del os.environ["ENVIRONMENT"]
-        if "HOT_RELOAD" in os.environ:
-            del os.environ["HOT_RELOAD"]
-
         with patch("bot.cli.DiscordBot"), patch("bot.cli.setup_logging"):
             result = runner.invoke(app, ["run", "--dev"])
 
             assert result.exit_code == 0
             assert os.environ.get("ENVIRONMENT") == "development"
-            assert os.environ.get("HOT_RELOAD") == "true"
 
     def test_log_level_sets_environment_var(self):
         """Test that log level option sets environment variable."""


### PR DESCRIPTION
## Summary
- add a root-level AGENTS.md that explains the runtime architecture, plugin workflow, coding standards, and testing expectations for the Discord bot framework
- remove obsolete hot reload references from documentation, the CLI, and CLI tests now that the feature is no longer supported

## Testing
- `uv run pytest` *(fails: missing configuration such as `DISCORD_TOKEN` and plugin metadata in the baseline test environment)*
- `uv run pytest tests/unit/bot/test_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68cc0d32a8fc8327a68a2b47df742817