### PR TITLE
Standardize permission nodes across plugins and refresh docs

### DIFF
--- a/docs/permissions/migration.md
+++ b/docs/permissions/migration.md
@@ -1,0 +1,115 @@
+# Permission Migration Guide
+
+This guide helps existing deployments migrate stored permission data from the legacy node scheme to the new hierarchical
+structure. The bot will automatically discover the new nodes after this change set, but database rows that reference the old
+values must be updated to avoid orphaned grants.
+
+## 1. Preparation
+1. **Back up your database** – copy the SQLite file or take a snapshot of your PostgreSQL instance.
+2. **Stop the bot** – prevent new permission changes while the migration is running.
+3. **Pull the latest code** – ensure this commit is deployed so that the new permission names are available.
+
+## 2. Let the bot discover the new nodes
+Restart the bot once after deploying the code. During start-up the `PermissionManager` will scan loaded plugins and insert the new
+permission rows (for example `basic.music.queue.view`, `music.queue.manage`, etc.).
+
+## 3. Remap existing role grants
+Run the following Python helper once inside your project environment (e.g. `uv run python migrate_permissions.py`). It copies
+existing grants from legacy nodes to their replacements and removes obsolete entries.
+
+```python
+# save as migrate_permissions.py and execute with `uv run python migrate_permissions.py`
+import asyncio
+
+from bot.database import db_manager
+from bot.database.models import Permission, RolePermission
+
+# Only nodes that require explicit migration (basic.* nodes remain publicly accessible)
+PERMISSION_MAP = {
+    "admin.permissions": ["admin.permissions.manage"],
+    "admin.config": ["admin.config.manage"],
+    "admin.plugins": ["admin.plugins.manage"],
+    "admin.music.settings": ["music.settings.manage"],
+    "links.manage": ["links.collection.manage", "links.manage"],
+    "moderation.kick": ["moderation.members.kick"],
+    "moderation.ban": ["moderation.members.ban"],
+    "moderation.timeout": ["moderation.members.timeout"],
+    "moderation.warn": ["moderation.members.warn"],
+    "moderation.nickname": ["moderation.members.nickname"],
+    "moderation.mute": ["moderation.members.mute"],
+    "moderation.purge": ["moderation.channels.purge"],
+    "moderation.slowmode": ["moderation.channels.slowmode"],
+    "moderation.music.manage": ["music.queue.manage", "music.voice.manage", "music.manage"],
+    "music.manage": ["music.queue.manage", "music.voice.manage", "music.manage"],
+    "music.settings": ["music.settings.manage"],
+}
+
+async def migrate() -> None:
+    async with db_manager.session() as session:
+        # Look up all permissions we need in a single query
+        nodes_to_fetch = set(PERMISSION_MAP.keys()) | {n for repl in PERMISSION_MAP.values() for n in repl}
+        permissions = await session.execute(Permission.__table__.select().where(Permission.node.in_(nodes_to_fetch)))
+        perm_rows = {row["node"]: row for row in permissions.mappings()}
+
+        for legacy, replacements in PERMISSION_MAP.items():
+            legacy_perm = perm_rows.get(legacy)
+            if not legacy_perm:
+                continue
+
+            # Identify all role grants that currently reference the legacy node
+            role_perms = await session.execute(
+                RolePermission.__table__.select().where(RolePermission.permission_id == legacy_perm["id"])
+            )
+            role_permissions = list(role_perms.mappings())
+
+            for replacement in replacements:
+                replacement_perm = perm_rows.get(replacement)
+                if not replacement_perm:
+                    print(f"Skipping {replacement} – ensure the bot has been started once to create it.")
+                    continue
+
+                for rp in role_permissions:
+                    exists = await session.execute(
+                        RolePermission.__table__.select().where(
+                            (RolePermission.guild_id == rp["guild_id"]) &
+                            (RolePermission.role_id == rp["role_id"]) &
+                            (RolePermission.permission_id == replacement_perm["id"])
+                        )
+                    )
+                    if exists.first() is None:
+                        session.add(
+                            RolePermission(
+                                guild_id=rp["guild_id"],
+                                role_id=rp["role_id"],
+                                permission_id=replacement_perm["id"],
+                                granted=rp["granted"],
+                            )
+                        )
+
+            # Remove the legacy grant to keep the database tidy
+            await session.execute(
+                RolePermission.__table__.delete().where(RolePermission.permission_id == legacy_perm["id"])
+            )
+            await session.execute(Permission.__table__.delete().where(Permission.id == legacy_perm["id"]))
+
+        await session.commit()
+
+if __name__ == "__main__":
+    asyncio.run(migrate())
+    print("✅ Permission migration complete")
+```
+
+> **Tip:** If you operate on PostgreSQL, execute the script inside the same environment where the bot normally runs so that the
+> configured database URL is reused.
+
+The migration also seeds the new plugin-level aggregators (`admin.manage`, `moderation.manage`, `music.manage`, `links.manage`).
+Granting these nodes to a role provides the entire plugin toolset without listing every individual permission.
+
+## 4. Clear caches and verify
+1. Start the bot again – the permission cache is automatically rebuilt on launch.
+2. Use the admin panel (`/permission list`) to verify that only the new nodes appear and that roles still have the expected access.
+3. Update any documentation or runbooks that referenced the old node names.
+
+## 5. Optional clean-up
+- Remove any manual grants for `basic.*` nodes – those permissions are implicitly available to everyone.
+- If you manage permissions in infrastructure-as-code, update templates to the new naming scheme.

--- a/docs/permissions/permission_audit.md
+++ b/docs/permissions/permission_audit.md
@@ -1,0 +1,68 @@
+# Permission Audit Report
+
+This document captures the results of the repository-wide permission review. Every plugin was inspected to catalogue existing
+permission nodes, identify inconsistencies, and realign them with the new naming standard of `<plugin>.<category>.<action>` while
+reserving the `basic.` prefix for commands that should be universally available.
+
+## Summary
+- All legacy permission nodes were catalogued and mapped to the new hierarchy.
+- `basic.` nodes now explicitly encode plugin context (for example `basic.music.queue.view`).
+- Management and administration actions now live under their owning plugin (for example `music.voice.manage` instead of
+  `moderation.music.manage`).
+- The `PermissionManager` was updated to understand the new hierarchy, wildcard matching rules, and database category labels.
+- Plugin-wide aggregators (`admin.manage`, `moderation.manage`, `music.manage`, `links.manage`) allow roles to inherit full
+  access without enumerating every sub-permission.
+
+## Old → New Permission Mapping
+
+| Plugin | Legacy Node | Replacement Node(s) | Notes |
+| --- | --- | --- | --- |
+| Admin | `admin.permissions` | `admin.permissions.manage` | Clarifies that the command grants management rights. |
+| Admin | `admin.config` | `admin.config.manage` | Covers both prefix and autorole configuration commands. |
+| Admin | `admin.plugins` | `admin.plugins.manage` | Reserved for future plugin lifecycle commands. |
+| Music | `admin.music.settings` | `music.settings.manage` | Ownership moved to the music plugin namespace. |
+| Help | `basic.commands` | `basic.help.commands.view` | Exposes command listings to everyone by default. |
+| Help | `basic.plugins` | `basic.help.plugins.view` | Mirrors the command list node for plugin listings. |
+| Utility | `basic.convert` | `basic.utility.convert.use` | Groups timestamp/base64 conversions under the utility plugin. |
+| Utility | `basic.tools` | `basic.utility.tools.use` | Covers QR codes, reminders, polls, and related tools. |
+| Utility | `basic.info` | `basic.utility.info.view` | Applies to user info, avatar, and weather lookups. |
+| Fun | `basic.games` | `basic.fun.games.play` | Shared node for all mini-games, trivia, and RNG commands. |
+| Fun | `basic.images` | `basic.fun.images.view` | Used by meme/image fetching commands. |
+| Links | `links.view` | `basic.links.view` | Marked as universally accessible link browsing. |
+| Links | `links.manage` | `links.collection.manage`, `links.manage` | Separate CRUD actions from the optional plugin-wide aggregator. |
+| Moderation | `moderation.kick` | `moderation.members.kick` | Member management permissions are grouped under `members`. |
+| Moderation | `moderation.ban` | `moderation.members.ban` | Applies to both ban and unban commands. |
+| Moderation | `moderation.timeout` | `moderation.members.timeout` | |
+| Moderation | `moderation.warn` | `moderation.members.warn` | |
+| Moderation | `moderation.nickname` | `moderation.members.nickname` | |
+| Moderation | `moderation.mute` | `moderation.members.mute` | Reserved for future mute support. |
+| Moderation | `moderation.purge` | `moderation.channels.purge` | Channel-scoped actions grouped under `channels`. |
+| Moderation | `moderation.slowmode` | `moderation.channels.slowmode` | |
+| Music | `moderation.music.manage` | `music.queue.manage`, `music.voice.manage` | Split responsibilities between queue control and voice lifecycle. |
+| Music | `music.play` | `basic.music.playback.control` | Default playback commands (play, pause, resume, etc.). |
+| Music | `basic.music.play` | `basic.music.playback.control`, `basic.music.queue.view`, `basic.music.queue.control`, `basic.music.voice.control`, `basic.music.search.use` | Former catch-all node replaced by specific contexts. |
+| Music | `music.manage` | `music.queue.manage`, `music.voice.manage` | Distinguishes queue vs. voice administrative actions. |
+| Music | `music.settings` | `music.settings.manage` | |
+
+## Newly Introduced Nodes
+
+In addition to the replacements above, the review surfaced several new descriptive nodes to express fine-grained intent:
+
+- `basic.music.queue.control` – shuffle/loop style queue controls that remain open to everyone.
+- `basic.music.queue.view` – queue/history/now-playing viewers.
+- `basic.music.voice.control` – joining channels and adjusting volume.
+- `basic.music.search.use` – interactive track search picker.
+- `music.voice.manage` – controlled disconnect operations.
+- `basic.links.view` – highlights that link browsing is public by default.
+- `basic.admin.info.view` – grants default access to telemetry commands such as `/bot-info` and `/server-info`.
+- `basic.admin.status.view` – default uptime/status visibility.
+- `admin.manage`, `moderation.manage`, `music.manage`, `links.manage` – high-level aggregators that grant the entire plugin's
+  permission set when assigned to a role.
+
+These nodes are discoverable by the permission discovery system and are documented per plugin in the updated AGENTS guides.
+
+## Next Steps
+- Apply the migration guide (`docs/permissions/migration.md`) to update any existing database rows or role assignments that still
+  reference the legacy nodes.
+- Audit any third-party plugins to ensure they follow the same hierarchy before deployment.
+- Update provisioning scripts or infrastructure automation to seed the new nodes where required.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -435,7 +435,7 @@ class UtilsPlugin(BasePlugin):
     @command(
         name="serverinfo",
         description="Display server information",
-        permission_node="basic.info"
+        permission_node="basic.utility.info.view"
     )
     async def server_info(self, ctx) -> None:
         guild = ctx.get_guild()

--- a/plugins/admin/AGENTS.md
+++ b/plugins/admin/AGENTS.md
@@ -1,22 +1,94 @@
 # Admin Plugin Guidelines
 
-This plugin now follows the shared layout used by every plugin:
+## Overview
+- Provides guild administration utilities: role permission management, prefix/autorole configuration, and rich telemetry about
+  the bot and current guild.
+- Powers the control panel at `/plugin/admin` with REST endpoints for viewing and editing permission assignments.
+- Ships Miru pagination views to browse large permission sets directly inside Discord.
+- Primary permission nodes: `admin.manage` for plugin-wide access, `admin.permissions.manage`, `admin.config.manage`,
+  `admin.plugins.manage`, plus the public `basic.admin.info.view` and `basic.admin.status.view` nodes that expose telemetry
+  commands to everyone by default.
+- Optional dependency: [`psutil`](https://pypi.org/project/psutil/) enhances the uptime command with CPU/memory statistics.
 
+## Architecture
+- Package layout mirrors the standard plugin contract:
+  - `plugin.py` exposes `AdminPlugin` (re-exported from `__init__.py`) and registers all commands during `_register_commands()`.
+  - `commands/` holds the command factories:
+    - `settings.py` → `/permission`, `/prefix`, `/autorole` (uses `admin.permissions.manage` and `admin.config.manage`).
+    - `info.py` → informational commands (`/bot-info`, `/server-info`, `/uptime`).
+  - `config.py` centralises embed colours, prefix validation rules, and feature mappings for server flags.
+  - `views/__init__.py` defines Miru pagination components for listing permissions and role grants.
+  - `web/` registers FastAPI routes for the admin panel (`web/routes.py`) and renders templates from `templates/panel.html`.
+  - `models/` is currently empty but reserved for future admin-specific persistence.
+- The plugin inherits both `BasePlugin` (command/setting helpers) and `WebPanelMixin` (panel registration) from the framework.
+- Autorole membership and other lightweight settings are stored via `BasePlugin.get_setting`/`set_setting` in the shared database.
+
+## Commands
+| Command | Description | Permission Node | Notes |
+| --- | --- | --- | --- |
+| `/permission [action] [role] [permission]` | List, grant, or revoke permission nodes for a role. Supports wildcards and pagination. | `admin.permissions.manage` | The default action is `list`. Wildcards (`moderation.*`, `*.queue.manage`) are resolved through the `PermissionManager`. |
+| `/prefix [new_prefix]` | View or update the guild prefix used by the prefix command handler. | `admin.config.manage` | Enforces `PREFIX_MAX_LENGTH` (5) and disallows quotes/backticks/whitespace defined in `config.py`. |
+| `/autorole <add/remove/list/clear> [role]` | Configure roles automatically applied to new members. | `admin.config.manage` | Stored per guild via plugin settings; validates role hierarchy before assignment. |
+| `/bot-info` (`/info`) | Displays guild count, plugin count, database status, and bot metadata. | `basic.admin.info.view` | `basic.` nodes are implicitly granted to everyone; psutil enhances the output when installed. |
+| `/server-info` | Rich guild breakdown with counts, features, and artwork. | `basic.admin.info.view` | Pulls feature labels from `SERVER_FEATURE_MAPPING`; granted to all members by default. |
+| `/uptime` (`/status`) | Shows bot uptime, start time, process metrics, and host statistics. | `basic.admin.status.view` | Also public via the `basic.` prefix; falls back gracefully when `psutil` is missing. |
+
+## Configuration
+- No dedicated environment variables; the plugin relies on the global `config.settings` for database access and general bot
+  configuration.
+- `config.py` exposes validation helpers:
+  - `PREFIX_MAX_LENGTH` (default 5 characters).
+  - `PREFIX_DISALLOWED_CHARS` (quotes, backticks, whitespace control characters).
+  - `AUTOROLE_VALID_ACTIONS` to validate autorole sub-commands.
+  - Colour constants reused by embeds.
+- Autorole data is persisted as a list of role IDs under the key `"autoroles"` in the shared plugin settings table.
+- The web panel relies on the global FastAPI app registered through `WebPanelMixin`. No extra configuration is required beyond the
+  global web settings (host/port/secret) handled by the framework.
+
+## Development Guidelines
+- Keep new commands inside `commands/` modules; each factory should return decorated coroutine functions that `AdminPlugin` attaches
+  during `_register_commands()`.
+- Use `BasePlugin.smart_respond` for responses that should adapt to slash vs prefix invocations.
+- Wrap database access in `async with plugin.bot.db.session():` blocks and commit within the context.
+- The permission panel expects `Permission.description` and `Permission.category` fields to be populated; when adding new admin
+  permissions ensure metadata includes friendly descriptions.
+- Run focused tests after changes: `uv run pytest tests/unit/plugins/admin`.
+- Web panel changes should maintain parity with the REST helpers in `web/routes.py`; keep JSON responses stable because the front-end
+  JavaScript in `templates/panel.html` consumes them directly.
+
+## Troubleshooting
+- **Permission not appearing in panel:** restart the bot or call `permission refresh` (admin command) to trigger `PermissionManager`
+  discovery. Ensure the command metadata includes `permission_node`.
+- **Pagination buttons unresponsive:** check that the global Miru client is initialised (`DiscordBot` attaches it on startup). The
+  view will log an error if `miru_client` is missing.
+- **Prefix changes failing:** validate against `PREFIX_MAX_LENGTH` and confirm the database user has write access.
+- **Autorole assignment fails on join:** confirm the bot role sits above the target role; the command already prevents misconfiguration
+  but manual database edits can still break hierarchy expectations.
+
+## Examples
+### Add a scoped admin command
+```python
+from bot.plugins.commands import command
+
+@command(
+    name="reload-config",
+    description="Reload external configuration",  # Describe the behaviour clearly
+    permission_node="admin.plugins.manage",
+)
+async def reload_config(ctx: lightbulb.Context) -> None:
+    plugin = ctx.app.get_plugin("admin")  # type: ignore[attr-defined]
+    await plugin.bot.reload_configuration()
+    await plugin.smart_respond(ctx, "Configuration reloaded.")
 ```
-plugins/admin/
-├── commands/
-├── models/
-├── templates/
-├── views/
-└── web/
+
+### Fetch role permissions from the web panel API
+```python
+# GET /plugin/admin/api/guild/{guild_id}/role/{role_id}/permissions
+response = await http_client.get(
+    "https://your-panel.example/api/plugin/admin/api/guild/123456789/role/987654321/permissions",
+    headers={"Authorization": f"Bearer {token}"},
+)
+permissions = response.json()["permissions"]
 ```
 
-Key notes for future changes:
-
-- Keep the main plugin class in `plugin.py` and expose it from `__init__.py`.
-- Slash/prefix command factories belong in `commands/`; the existing helpers return decorated callables that get attached during plugin initialisation.
-- Miru UI classes live inside the `views` package. FastAPI web panel routes now live in `web/routes.py` and may import the plugin via `from ..plugin import AdminPlugin` for type hints.
-- The admin plugin currently has no bespoke database tables. If you introduce any, add them to `models/__init__.py` and remember to register them in `plugin.py`.
-- Templates used by the FastAPI panel should live under `templates/`.
-
-Follow the repository-wide formatting and lint rules (Black 135, Ruff). Run the plugin tests with `uv run pytest tests/unit/plugins/admin` when touching behaviour.
+Use these patterns to keep new features consistent with the rest of the plugin.

--- a/plugins/admin/README.md
+++ b/plugins/admin/README.md
@@ -13,7 +13,7 @@ The Admin plugin provides essential administrative tools for server owners and b
 #### `!permission` (Alias: `/permission`)
 Manage role permissions for the bot's command system.
 
-**Permission Required:** `admin.permissions`
+**Permission Required:** `admin.permissions.manage`
 
 **Usage:**
 - `!permission` - List all available permissions
@@ -29,6 +29,8 @@ Manage role permissions for the bot's command system.
 #### `!bot-info` (Aliases: `!info`, `/bot-info`)
 Display comprehensive bot information and statistics.
 
+**Permission Required:** `basic.admin.info.view` (granted to everyone by default)
+
 **Usage:** `!bot-info`
 
 **Information Displayed:**
@@ -42,6 +44,8 @@ Display comprehensive bot information and statistics.
 
 #### `!server-info` (Aliases: `!serverinfo`, `!guild-info`, `/server-info`)
 Display detailed server information and statistics.
+
+**Permission Required:** `basic.admin.info.view`
 
 **Usage:** `!server-info`
 
@@ -57,6 +61,8 @@ Display detailed server information and statistics.
 
 #### `!uptime` (Aliases: `!up`, `!status`, `/uptime`)
 Display bot uptime and system information.
+
+**Permission Required:** `basic.admin.status.view`
 
 **Usage:** `!uptime`
 
@@ -75,9 +81,12 @@ Display bot uptime and system information.
 
 The Admin plugin defines the following permission nodes:
 
-- `admin.config` - General administrative configuration
-- `admin.plugins` - Plugin management operations
-- `admin.permissions` - Permission system management
+- `admin.manage` - Grants full access to all admin plugin commands.
+- `admin.config.manage` - General administrative configuration.
+- `admin.plugins.manage` - Plugin management operations.
+- `admin.permissions.manage` - Permission system management.
+- `basic.admin.info.view` - Public info commands (bot/server stats).
+- `basic.admin.status.view` - Public uptime/status command.
 
 ## Dependencies
 

--- a/plugins/admin/__init__.py
+++ b/plugins/admin/__init__.py
@@ -6,7 +6,14 @@ PLUGIN_METADATA = {
     "author": "Bot Framework",
     "description": "Administrative commands for bot management",
     "dependencies": [],
-    "permissions": ["admin.config", "admin.plugins", "admin.permissions"],
+    "permissions": [
+        "admin.manage",
+        "admin.permissions.manage",
+        "admin.config.manage",
+        "admin.plugins.manage",
+        "basic.admin.info.view",
+        "basic.admin.status.view",
+    ],
 }
 
 

--- a/plugins/admin/commands/info.py
+++ b/plugins/admin/commands/info.py
@@ -29,6 +29,7 @@ def setup_info_commands(plugin: AdminPlugin) -> list[Callable[..., Any]]:
         name="bot-info",
         description="Display bot information and statistics",
         aliases=["info"],
+        permission_node="basic.admin.info.view",
     )
     async def bot_info(ctx: lightbulb.Context) -> None:
         try:
@@ -71,6 +72,7 @@ def setup_info_commands(plugin: AdminPlugin) -> list[Callable[..., Any]]:
         name="server-info",
         description="Display server information and statistics",
         aliases=["serverinfo", "guild-info"],
+        permission_node="basic.admin.info.view",
     )
     async def server_info(ctx: lightbulb.Context) -> None:
         try:
@@ -150,6 +152,7 @@ def setup_info_commands(plugin: AdminPlugin) -> list[Callable[..., Any]]:
         name="uptime",
         description="Display bot uptime and system information",
         aliases=["up", "status"],
+        permission_node="basic.admin.status.view",
     )
     async def uptime(ctx: lightbulb.Context) -> None:
         try:

--- a/plugins/admin/commands/settings.py
+++ b/plugins/admin/commands/settings.py
@@ -32,7 +32,7 @@ def setup_settings_commands(plugin: AdminPlugin) -> list[Callable[..., Any]]:
     @command(
         name="permission",
         description="Manage role permissions",
-        permission_node="admin.permissions",
+        permission_node="admin.permissions.manage",
         arguments=[
             CommandArgument(
                 "action",
@@ -188,7 +188,7 @@ def setup_settings_commands(plugin: AdminPlugin) -> list[Callable[..., Any]]:
     @command(
         name="prefix",
         description="View or set the bot's prefix for this server",
-        permission_node="admin.config",
+        permission_node="admin.config.manage",
         arguments=[
             CommandArgument(
                 "new_prefix",
@@ -294,7 +294,7 @@ def setup_settings_commands(plugin: AdminPlugin) -> list[Callable[..., Any]]:
     @command(
         name="autorole",
         description="Configure roles automatically assigned to new members",
-        permission_node="admin.config",
+        permission_node="admin.config.manage",
         arguments=[
             CommandArgument(
                 "action",

--- a/plugins/fun/AGENTS.md
+++ b/plugins/fun/AGENTS.md
@@ -1,23 +1,92 @@
 # Fun Plugin Guidelines
 
-Layout mirror for all plugins:
+## Overview
+- Delivers entertainment commands (jokes, memes, quotes, facts) and lightweight games (dice rolls, coin flips, trivia).
+- Provides interactive Miru views for trivia and would-you-rather prompts with button-based responses.
+- Maintains an `aiohttp.ClientSession` for calling external APIs with graceful fallbacks to bundled defaults.
+- Primary permission nodes:
+  - `basic.fun.games.play` – shared by all game-oriented commands.
+  - `basic.fun.images.view` – protects meme/image retrieval commands.
+- Optional web panel (`/plugin/fun`) can surface high scores or activity metrics via FastAPI routes.
 
+## Architecture
+- `plugin.py` defines `FunPlugin` which inherits `BasePlugin` and `WebPanelMixin`. It initialises an `aiohttp` session in `on_load`
+  and closes it during `on_unload`.
+- `commands/`
+  - `basic.py` – contains `/ping` health check.
+  - `games.py` – RNG utilities (`/roll`, `/coinflip`, `/8ball`, `/choose`, `/random`), interactive trivia (`/trivia`), and would-
+    you-rather (`/would-you-rather`). All routes use `basic.fun.games.play`.
+  - `content.py` – content fetchers (`/joke`, `/quote`, `/meme`, `/fact`). Only `/meme` requires `basic.fun.images.view`; others are
+    public.
+- `config.py` supplies API endpoints, default fallback data, RNG limits, and emoji sets for embed decoration.
+- `views/` exposes `TriviaView` and `WouldYouRatherView` used by the interactive commands.
+- `web/` (optional) can register panel routes via `register_fun_routes`; currently a placeholder for future expansion.
+- The plugin does not persist state beyond runtime counters (no custom models). Shared logging happens through `plugin.log_command_usage`.
+
+## Commands
+| Command | Description | Permission Node |
+| --- | --- | --- |
+| `/ping` | Quick responsiveness check. | _None_ |
+| `/roll [dice]` | Roll dice using NdN notation; validates ranges defined in `config.DICE_LIMITS`. | `basic.fun.games.play` |
+| `/coinflip` | Flip a coin with emoji-rich output. | `basic.fun.games.play` |
+| `/8ball <question>` | Magic 8-ball style responses. | `basic.fun.games.play` |
+| `/choose <option1> <option2>` | Choose between supplied options. | `basic.fun.games.play` |
+| `/random [min] [max]` | Random integer within configurable bounds. | `basic.fun.games.play` |
+| `/trivia [category]` | Starts an interactive multiple-choice trivia round with Miru buttons. | `basic.fun.games.play` |
+| `/would-you-rather` | Presents a prompt with button reactions for A/B choices. | `basic.fun.games.play` |
+| `/joke` | Fetches a random joke via API or fallback list. | _None_ |
+| `/quote` | Provides motivational quotes with attribution. | _None_ |
+| `/meme` | Pulls memes from configured APIs, falls back to Imgflip if necessary. | `basic.fun.images.view` |
+| `/fact` | Returns a random educational fact. | _None_ |
+
+## Configuration
+- All external endpoints live in `config.API_ENDPOINTS`; adjust or extend this mapping when adding new content sources.
+- RNG and trivia defaults are also defined in `config.py`:
+  - `DICE_LIMITS` and `RANDOM_NUMBER_LIMIT` bound numeric outputs.
+  - `DEFAULT_TRIVIA_QUESTIONS`, `DEFAULT_WYR_QUESTIONS`, and fallback lists keep commands functional offline.
+- No plugin-specific environment variables; relies on the global `config.settings` for tokens and bot metadata.
+- HTTP interactions require the `aiohttp` extra declared in the project dependencies.
+
+## Development Guidelines
+- Always guard API calls with `if plugin.session:` and provide fallback data; the existing commands model this pattern.
+- Register new commands through the factory functions in `commands/` and let `_register_commands()` attach them.
+- Prefer `plugin.smart_respond` for outputs so slash/prefix parity is preserved.
+- Reuse logging helpers (`plugin.log_command_usage`) to capture metrics in the shared database.
+- Update `config.py` when adding new emojis, endpoints, or range constants so future contributors have a single source of truth.
+- Run plugin tests after changes: `uv run pytest tests/unit/plugins/fun`.
+
+## Troubleshooting
+- **HTTP failures**: All commands already fall back to bundled defaults. If you see repeated errors in logs, verify outbound
+  connectivity and inspect the JSON structure of upstream APIs.
+- **Miru interactions not responding**: ensure the global Miru client is initialised. Trivia view logs debugging information when
+  failing to start.
+- **Rate limiting**: APIs used (`Official Joke API`, `Quotable`, `wttr.in`) are public but may throttle; consider caching responses
+  or adding more fallback data.
+
+## Examples
+### Adding a new content command
+```python
+from bot.plugins.commands import command
+
+@command(name="fact-cat", description="Cat-themed facts")
+async def cat_fact(ctx: lightbulb.Context) -> None:
+    if not plugin.session:
+        fact = "Cats sleep for 70% of their lives."
+    else:
+        async with plugin.session.get("https://catfact.ninja/fact") as resp:
+            data = await resp.json()
+            fact = data.get("fact", "Cats have flexible spines for quick jumps.")
+    embed = plugin.create_embed(title="🐱 Cat Fact", description=fact)
+    await ctx.respond(embed=embed)
 ```
-plugins/fun/
-├── commands/
-├── models/
-├── templates/
-├── views/
-└── web/
+
+### Triggering a trivia game programmatically
+```python
+from plugins.fun.views import TriviaView
+
+view = TriviaView(plugin, ctx.author.id, question_set)
+await ctx.respond(embed=view.build_embed(), components=view)
+plugin.bot.miru_client.start_view(view)
 ```
 
-Pointers:
-
-- `plugin.py` holds `FunPlugin` and remains the entry point exposed via `__init__.py`.
-- Command factory helpers in `commands/` attach decorated coroutine functions to the plugin; extend those modules when adding new commands so registration happens through `_register_commands()`.
-- Miru trivia and mini-game views belong in `views/__init__.py`. Keep shared presentation helpers alongside them if needed.
-- FastAPI panel routes live in `web/routes.py`; call `register_fun_routes()` from the plugin's `register_web_routes()` implementation.
-- The plugin does not yet persist data; add future models to `models/__init__.py` and remember to register them from `FunPlugin`.
-- Web assets for the panel live in `templates/`.
-
-Adhere to repo formatting/linting. When touching behaviour run `uv run pytest tests/unit/plugins/fun`.
+Follow these conventions to ensure new commands integrate smoothly with the existing session handling and UI patterns.

--- a/plugins/fun/__init__.py
+++ b/plugins/fun/__init__.py
@@ -6,7 +6,7 @@ PLUGIN_METADATA = {
     "author": "Bot Framework",
     "description": "Fun commands and games for entertainment",
     "dependencies": [],
-    "permissions": ["fun.games", "fun.images"],
+    "permissions": ["basic.fun.games.play", "basic.fun.images.view"],
 }
 
 

--- a/plugins/fun/commands/content.py
+++ b/plugins/fun/commands/content.py
@@ -130,7 +130,7 @@ def setup_content_commands(plugin: FunPlugin) -> list[Callable[..., Any]]:
     @command(
         name="meme",
         description="Get a random meme",
-        permission_node="basic.images",
+        permission_node="basic.fun.images.view",
     )
     async def random_meme(ctx: lightbulb.Context) -> None:
         try:

--- a/plugins/fun/commands/games.py
+++ b/plugins/fun/commands/games.py
@@ -33,7 +33,7 @@ def setup_game_commands(plugin: FunPlugin) -> list[Callable[..., Any]]:
         name="roll",
         description="Roll dice (format: NdN, e.g., 2d6)",
         aliases=["r"],
-        permission_node="basic.games",
+        permission_node="basic.fun.games.play",
         arguments=[
             CommandArgument(
                 "dice",
@@ -117,7 +117,7 @@ def setup_game_commands(plugin: FunPlugin) -> list[Callable[..., Any]]:
             await plugin.smart_respond(ctx, embed=embed, ephemeral=True)
             await plugin.log_command_usage(ctx, "roll", False, str(exc))
 
-    @command(name="coinflip", description="Flip a coin", permission_node="basic.games")
+    @command(name="coinflip", description="Flip a coin", permission_node="basic.fun.games.play")
     async def flip_coin(ctx: lightbulb.Context) -> None:
         try:
             result = random.choice(["Heads", "Tails"])
@@ -139,7 +139,7 @@ def setup_game_commands(plugin: FunPlugin) -> list[Callable[..., Any]]:
     @command(
         name="8ball",
         description="Ask the magic 8-ball a question",
-        permission_node="basic.games",
+        permission_node="basic.fun.games.play",
         arguments=[CommandArgument("question", hikari.OptionType.STRING, "Your question for the 8-ball")],
     )
     async def magic_8ball(ctx: lightbulb.Context, question: str) -> None:
@@ -231,7 +231,7 @@ def setup_game_commands(plugin: FunPlugin) -> list[Callable[..., Any]]:
         name="random",
         description="Generate random numbers within a range",
         aliases=["rng", "rand"],
-        permission_node="basic.games",
+        permission_node="basic.fun.games.play",
         arguments=[
             CommandArgument(
                 "min_value",
@@ -296,7 +296,7 @@ def setup_game_commands(plugin: FunPlugin) -> list[Callable[..., Any]]:
     @command(
         name="trivia",
         description="Start an interactive trivia question",
-        permission_node="basic.games",
+        permission_node="basic.fun.games.play",
     )
     async def trivia_question(ctx: lightbulb.Context) -> None:
         try:
@@ -367,7 +367,7 @@ def setup_game_commands(plugin: FunPlugin) -> list[Callable[..., Any]]:
         name="would-you-rather",
         description="Get a would you rather question",
         aliases=["wyr", "wouldyourather"],
-        permission_node="basic.games",
+        permission_node="basic.fun.games.play",
     )
     async def would_you_rather(ctx: lightbulb.Context) -> None:
         try:

--- a/plugins/help/AGENTS.md
+++ b/plugins/help/AGENTS.md
@@ -1,22 +1,73 @@
 # Help Plugin Guidelines
 
-Canonical structure:
+## Overview
+- Centralised help system that mirrors both slash and prefix commands, complete with pagination and plugin filtering.
+- Generates embeds dynamically using the command registry metadata and exposes a `/help` command with intelligent search.
+- Integrates with Miru to render dropdown selection menus for plugin navigation and pagination controls.
+- Primary permission nodes:
+  - `basic.help.commands.view` – grants access to the `/commands` listing.
+  - `basic.help.plugins.view` – allows viewing `/plugins` overview.
+- Designed to work even when optional components (Miru, prefix handler) are unavailable by gracefully degrading to plain embeds.
 
+## Architecture
+- `plugin.py` exposes `HelpPlugin`, extending `BasePlugin`. It registers commands directly on the class rather than returning them
+  from factories (help commands benefit from tight integration with the plugin state).
+- `models/command_info.py` contains `CommandInfoManager`, responsible for caching command metadata gathered from the registry and
+  the plugin loader.
+- `views/`:
+  - `embed_generators.py` holds reusable embed builders for general help, command listings, and plugin information.
+  - `menus.py` defines Miru dropdowns/pagination (`PluginSelectWithPaginationView`).
+- `templates/` and `web/` are placeholders for future web panel expansion; currently unused.
+- No custom persistence; everything is derived from the in-memory command registry and `PLUGIN_METADATA` of loaded plugins.
+
+## Commands
+| Command | Description | Permission Node |
+| --- | --- | --- |
+| `/help [query]` | Smart help entry point. With no arguments shows an overview; with input searches for commands or plugins. | _None_ |
+| `/commands` (`/cmds`) | Lists all registered commands grouped by plugin. | `basic.help.commands.view` |
+| `/plugins` (`/plugin-list`) | Shows metadata (version, author, description, permissions) for loaded plugins. | `basic.help.plugins.view` |
+
+## Configuration
+- No environment variables or plugin-specific settings; the plugin introspects loaded plugins and command metadata at runtime.
+- Behaviour toggles:
+  - `config.py` exposes `HelpConfig` (see `show_permissions` flag) allowing consumers to configure whether permission nodes appear
+    in the generated embeds.
+- The plugin respects whichever command prefix is configured globally via `DiscordBot.get_guild_prefix` when building examples.
+
+## Development Guidelines
+- New helper methods should live in `views/embed_generators.py` to keep embed formatting centralised.
+- When extending the help output, prefer editing `EmbedGenerators` rather than modifying command handlers directly.
+- Miru components should be registered through `PluginSelectWithPaginationView`; ensure the global Miru client is started before
+  expecting interactive elements to work.
+- To expose additional metadata (e.g., usage analytics) extend `CommandInfoManager` to gather the necessary data.
+- After modifying behaviour run `uv run pytest tests/unit/plugins/help` – the suite includes regression tests for embed content
+  and permission visibility.
+
+## Troubleshooting
+- **Missing commands in help listings**: ensure new commands register metadata via the unified decorator (`bot.plugins.commands.command`).
+- **Miru menus not showing**: double-check that Miru is installed and the bot initialises the global client. The help plugin will
+  fall back to plain embeds if the view has no children.
+- **Permission nodes absent from embeds**: confirm `HelpConfig.show_permissions` (in `config.py`) is `True`.
+
+## Examples
+### Extending the command listing
+```python
+from plugins.help.views.embed_generators import EmbedGenerators
+
+class CustomEmbedGenerators(EmbedGenerators):
+    async def get_commands_list(self) -> hikari.Embed:
+        embed = await super().get_commands_list()
+        embed.set_footer("Tip: Use /help <command> for detailed usage")
+        return embed
 ```
-plugins/help/
-├── commands/
-├── models/
-├── templates/
-├── views/
-└── web/
+
+### Registering a custom help page
+```python
+@command(name="staff-commands", description="List staff-specific utilities", permission_node="basic.help.commands.view")
+async def staff_commands(self, ctx: lightbulb.Context) -> None:
+    embed = self.create_embed(title="🛡️ Staff Utilities")
+    embed.description = "\n".join("• `/mod action`" for action in ["ban", "timeout", "purge"])
+    await ctx.respond(embed=embed)
 ```
 
-Important conventions:
-
-- `plugin.py` exports `HelpPlugin` (re-exported via `__init__.py`). Keep command implementations on the plugin class.
-- Store any reusable data helpers under `models/`. `CommandInfoManager` lives in `models/command_info.py`; extend this module or add siblings rather than creating new top-level files.
-- Presentation logic and Miru views live in the `views` package. `views/embed_generators.py` houses embed builders, while interactive dropdowns sit in `views/menus.py` and are re-exported through `views/__init__.py`.
-- Use `templates/` for web assets if a panel is ever added; a `.gitkeep` is present so the directory stays tracked.
-- The `web/` package is available for FastAPI routes once a control panel is required.
-
-Follow repository formatting and lint rules. Run `uv run pytest tests/unit/plugins/help` after changing behaviour.
+Follow these conventions to keep the help system consistent and automatically discoverable.

--- a/plugins/help/__init__.py
+++ b/plugins/help/__init__.py
@@ -6,7 +6,7 @@ PLUGIN_METADATA = {
     "author": "Bot Framework",
     "description": "Comprehensive help system showing commands and usage information",
     "dependencies": [],
-    "permissions": ["basic.commands", "basic.plugins"],
+    "permissions": ["basic.help.commands.view", "basic.help.plugins.view"],
 }
 
 

--- a/plugins/help/plugin.py
+++ b/plugins/help/plugin.py
@@ -163,7 +163,7 @@ class HelpPlugin(BasePlugin):
         name="commands",
         description="List all available commands organized by plugin",
         aliases=["cmds"],
-        permission_node="basic.commands",
+        permission_node="basic.help.commands.view",
     )
     async def list_commands(self, ctx: lightbulb.Context) -> None:
         """List all available commands organized by plugin."""
@@ -187,7 +187,7 @@ class HelpPlugin(BasePlugin):
         name="plugins",
         description="List all loaded plugins with their information",
         aliases=["plugin-list"],
-        permission_node="basic.plugins",
+        permission_node="basic.help.plugins.view",
     )
     async def list_plugins(self, ctx: lightbulb.Context) -> None:
         """List all loaded plugins with their information."""

--- a/plugins/links/AGENTS.md
+++ b/plugins/links/AGENTS.md
@@ -1,21 +1,75 @@
 # Links Plugin Guidelines
 
-Standard layout:
+## Overview
+- Stores curated links (documentation, support, custom resources) per guild with rich embed presentations.
+- Ships a set of default global links (GitHub, docs, panel, support) exposed through `DefaultLinkCommands`.
+- Supports full CRUD for guild-specific links with permission-guarded commands.
+- Primary permission nodes:
+  - `basic.links.view` – allows everyone to browse default/custom links.
+  - `links.collection.manage` – required to create, edit, or delete stored links.
+  - `links.manage` – optional aggregator granting full CRUD access to the plugin.
 
+## Architecture
+- `plugin.py` defines `LinksPlugin`, inheriting `DatabaseMixin` and `BasePlugin`.
+  - Registers the `Link` SQLAlchemy model and initialises command handler classes (`LinkCommands`, `DefaultLinkCommands`).
+- `commands/`
+  - `default_link_commands.py` – static showcase commands for core project links. Each command uses `basic.links.view` and renders
+    informative embeds.
+  - `link_commands.py` – user-managed link operations (`/links`, `/link add`, `/link remove`, `/link edit`, `/link info`). Management
+    routes require `links.collection.manage`.
+- `models/__init__.py` – contains the `Link` ORM model with guild/name uniqueness enforcement and relationships to `Guild`/`User`.
+- `config.py` exposes `links_settings` (default links and embed colours) to keep configuration centralised.
+- No templates or web routes are defined yet, but directories are present for future panel expansion.
+
+## Commands
+| Command | Description | Permission Node |
+| --- | --- | --- |
+| `/github`, `/panel`, `/docs`, `/support` | Static links populated from `links_settings.default_links`. | `basic.links.view` |
+| `/links` | Lists guild-specific links with pagination. | `basic.links.view` |
+| `/link info <name>` | Displays a single stored link. | `basic.links.view` |
+| `/link add <name> <url> [description]` | Creates a new link entry. | `links.collection.manage` |
+| `/link edit <name> [url] [description]` | Updates existing link metadata. | `links.collection.manage` |
+| `/link remove <name>` | Deletes a stored link. | `links.collection.manage` |
+
+## Configuration
+- Default links live in `config.py` under `links_settings.default_links`; update this mapping to adjust the stock commands.
+- The ORM model ensures `(guild_id, name)` uniqueness. Names are capped at 50 characters via the schema to avoid embed overflow.
+- No environment variables are required. The plugin uses the shared database connection configured globally by the framework.
+
+## Development Guidelines
+- When adding new management commands, use the helper classes (`LinkCommands`, `DefaultLinkCommands`) to keep separation between
+  system-provided and guild-provided links.
+- Always validate user input (URL format, duplicate detection) before writing to the database; existing methods provide examples
+  and throw descriptive errors.
+- Wrap database operations in `async with plugin.bot.db.session():` contexts to ensure proper transaction handling.
+- Reuse `plugin.create_embed` and `plugin.smart_respond` for consistent embed styling and ephemeral responses.
+- Run plugin-specific tests after changes: `uv run pytest tests/unit/plugins/links` (create new tests if functionality expands).
+
+## Troubleshooting
+- **Link not saving**: check logs for unique constraint violations. Names must be unique per guild.
+- **Embeds missing fields**: ensure descriptions stay within Discord embed limits (the commands truncate where necessary but
+  additional custom logic should follow suit).
+- **Permission errors**: verify the invoking role has `links.collection.manage` when performing mutations.
+
+## Examples
+### Adding a custom default link command
+```python
+class DefaultLinkCommands:
+    # ... existing commands ...
+
+    @command(name="status", description="Show the status page", permission_node="basic.links.view")
+    async def status_link(self, ctx) -> None:
+        embed = self.plugin.create_embed(
+            title="📈 Service Status",
+            description="Check real-time uptime information",
+        )
+        embed.add_field("Status Page", self.plugin._default_links["status"], inline=False)
+        await self.plugin.smart_respond(ctx, embed=embed)
 ```
-plugins/links/
-├── commands/
-├── models/
-├── templates/
-├── views/
-└── web/
+
+### Granting management access via admin command
+```python
+# /permission grant <role> links.manage
 ```
 
-Notes:
-
-- `plugin.py` contains `LinksPlugin` (exported via `__init__.py`). Keep startup logic there, including database model registration.
-- SQLAlchemy models are stored in `models/__init__.py`. Export new models via `__all__` and register them from the plugin class.
-- No interactive views or templates yet; keep placeholders in `views/`, `web/`, and `templates/` for future use.
-- Any command helpers should live in `commands/`. If you add new modules, update the plugin to attach them during initialisation.
-
-Observe the repository lint/format configuration when editing. Run targeted tests (`uv run pytest tests/unit/plugins`) if functionality changes.
+Keep new features consistent with these patterns to ensure links remain easy to manage and present.

--- a/plugins/links/__init__.py
+++ b/plugins/links/__init__.py
@@ -6,7 +6,7 @@ PLUGIN_METADATA = {
     "author": "Bot Framework",
     "description": "Easy access to important links and URLs",
     "dependencies": [],
-    "permissions": ["links.view", "links.manage"],
+    "permissions": ["basic.links.view", "links.collection.manage", "links.manage"],
 }
 
 

--- a/plugins/links/commands/default_link_commands.py
+++ b/plugins/links/commands/default_link_commands.py
@@ -23,7 +23,7 @@ class DefaultLinkCommands:
         name="github",
         aliases=["gh", "source"],
         description="Show the GitHub repository link",
-        permission_node="links.view",
+        permission_node="basic.links.view",
     )
     async def github_link(self, ctx) -> None:
         """Display the GitHub repository link with enhanced styling."""
@@ -47,7 +47,7 @@ class DefaultLinkCommands:
     @command(
         name="panel",
         description="Show the web control panel link",
-        permission_node="links.view",
+        permission_node="basic.links.view",
     )
     async def panel_link(self, ctx) -> None:
         """Display the web control panel link with enhanced styling."""
@@ -71,7 +71,7 @@ class DefaultLinkCommands:
     @command(
         name="docs",
         description="Show the documentation link",
-        permission_node="links.view",
+        permission_node="basic.links.view",
     )
     async def docs_link(self, ctx) -> None:
         """Display the documentation link with enhanced styling."""
@@ -97,7 +97,7 @@ class DefaultLinkCommands:
     @command(
         name="support",
         description="Show the support Discord server link",
-        permission_node="links.view",
+        permission_node="basic.links.view",
     )
     async def support_link(self, ctx) -> None:
         """Display the support Discord server link with enhanced styling."""

--- a/plugins/links/commands/link_commands.py
+++ b/plugins/links/commands/link_commands.py
@@ -35,7 +35,7 @@ class LinkCommands:
                 required=True,
             )
         ],
-        permission_node="links.view",
+        permission_node="basic.links.view",
     )
     async def show_link(self, ctx, name: str) -> None:
         """Display a custom link by name."""
@@ -95,7 +95,7 @@ class LinkCommands:
     @command(
         name="links",
         description="List all custom links for this server",
-        permission_node="links.view",
+        permission_node="basic.links.view",
     )
     async def list_links(self, ctx) -> None:
         """List custom server links."""
@@ -164,7 +164,7 @@ class LinkCommands:
                 required=False,
             ),
         ],
-        permission_node="links.manage",
+        permission_node="links.collection.manage",
     )
     async def add_link(self, ctx, name: str, url: str, description: str = None) -> None:
         """Add a custom link."""
@@ -225,7 +225,7 @@ class LinkCommands:
                 required=True,
             )
         ],
-        permission_node="links.manage",
+        permission_node="links.collection.manage",
     )
     async def remove_link(self, ctx, name: str) -> None:
         """Remove a custom link."""

--- a/plugins/moderation/AGENTS.md
+++ b/plugins/moderation/AGENTS.md
@@ -1,22 +1,78 @@
 # Moderation Plugin Guidelines
 
-Directory contract:
+## Overview
+- Provides core moderation tooling: kick/ban/unban, timeout, warn, nickname updates, message purging, and channel slowmode.
+- Relies on built-in Discord permission checks (role hierarchy, bot permissions) and surfaces detailed error feedback via embeds.
+- Primary permission nodes (granting plugin-wide access via `moderation.manage` plus fine-grained controls):
+  - `moderation.manage` – assigns the full moderation toolset to a role.
+  - `moderation.members.kick`
+  - `moderation.members.ban`
+  - `moderation.members.timeout`
+  - `moderation.members.warn`
+  - `moderation.members.nickname`
+  - `moderation.members.mute` (reserved for future mute functionality)
+  - `moderation.channels.purge`
+  - `moderation.channels.slowmode`
 
+## Architecture
+- `plugin.py` instantiates the plugin and registers command factories from `commands/`.
+- `commands/`
+  - `actions.py` – member-centric actions (kick, ban/unban, timeout, nickname changes). Each command validates role hierarchy and
+    uses `BasePlugin.smart_respond` for consistent messaging.
+  - `discipline.py` – warning system (issue, list, clear) that records reasons with timestamps in embeds.
+  - `channel.py` – channel management (bulk purge, enable/disable slowmode). Includes checks for bot permissions.
+- Currently stateless; future persistence (e.g., warning history) can be introduced via `DatabaseMixin` if required.
+- The package reserves `views/`, `models/`, and `web/` directories for future expansion but they are empty by default.
+
+## Commands
+| Command | Description | Permission Node |
+| --- | --- | --- |
+| `/kick <member> [reason]` | Kicks a member with audit log reason support. | `moderation.members.kick` |
+| `/ban <member> [delete_days] [reason]` | Bans a member, optionally deleting recent messages. | `moderation.members.ban` |
+| `/unban <user_id> [reason]` | Removes a ban. | `moderation.members.ban` |
+| `/timeout <member> <duration> [reason]` | Applies Discord timeout for a specified duration. | `moderation.members.timeout` |
+| `/nickname <member> <new_nick>` | Updates a member nickname, respecting hierarchy. | `moderation.members.nickname` |
+| `/warn <member> <reason>` | Issues a warning. | `moderation.members.warn` |
+| `/warnings <member>` | Lists stored warnings during runtime. | `moderation.members.warn` |
+| `/clear-warnings <member>` | Clears warning history. | `moderation.members.warn` |
+| `/purge <amount> [user]` | Bulk deletes messages from the current channel. | `moderation.channels.purge` |
+| `/slowmode <channel> <delay>` | Enables or disables slowmode with validation. | `moderation.channels.slowmode` |
+
+## Configuration
+- No dedicated plugin configuration or environment variables. Commands rely on Discord's permissions and the shared bot settings.
+- Duration parsing for timeouts leverages helper functions inside `commands/actions.py`; adjust there when supporting new formats.
+- Embeds use color constants defined within each command file for consistency (e.g., success vs error states).
+
+## Development Guidelines
+- Maintain strong validation: check for guild context, ensure bot has the necessary permissions, and compare role hierarchy before
+  executing actions. Existing commands demonstrate these checks.
+- When adding new moderation actions, place them in the appropriate factory (`actions`, `discipline`, or `channel`) and return
+  decorated coroutines that `plugin._register_commands()` will attach.
+- Use `plugin.log_command_usage` to record success/failure analytics for new commands.
+- If persistence is introduced (e.g., storing warnings), inherit from `DatabaseMixin`, define models in `models/`, and register them
+  in `plugin.py`.
+- Run focused tests: `uv run pytest tests/unit/plugins/moderation`.
+
+## Troubleshooting
+- **Command rejected with hierarchy error**: confirm the bot's highest role is above the target member and the invoking moderator has
+  sufficient privileges.
+- **No action occurs**: ensure the guild has granted the correct permission node to the moderator's role.
+- **Timeout command fails**: Discord imposes min/max duration constraints; refer to the validation logic in `actions.py` for current
+  limits.
+
+## Examples
+### Adding a soft-ban command
+```python
+@command(name="softban", description="Ban and immediately unban to delete messages", permission_node="moderation.members.ban")
+async def softban(ctx: lightbulb.Context, member: hikari.Member, reason: str | None = None) -> None:
+    await ctx.app.rest.ban_member(ctx.guild_id, member.id, delete_message_days=1, reason=reason)
+    await ctx.app.rest.unban_member(ctx.guild_id, member.id, reason="Softban cleanup")
+    await plugin.smart_respond(ctx, f"Softbanned {member.display_name} and cleared recent messages.")
 ```
-plugins/moderation/
-├── commands/
-├── models/
-├── templates/
-├── views/
-└── web/
+
+### Granting purge rights
+```python
+# /permission grant @Moderators moderation.channels.purge
 ```
 
-Guidance:
-
-- Keep the plugin entry point in `plugin.py` and export it from `__init__.py`.
-- Command factory modules inside `commands/` should return decorated callables ready to be attached in `_register_commands()`.
-- Miru views (none currently) belong in the `views` package; add modules there if UI components are added.
-- Place any future SQLAlchemy models in `models/__init__.py` and register them from `plugin.py`.
-- Web panel assets should live under `templates/` if introduced, with HTTP handlers defined under `web/`.
-
-Use repo-standard formatting/linting. Execute `uv run pytest tests/unit/plugins/moderation` when altering behaviour.
+Use these guidelines to keep moderation actions safe, predictable, and aligned with Discord's permission model.

--- a/plugins/moderation/README.md
+++ b/plugins/moderation/README.md
@@ -13,7 +13,7 @@ The Moderation plugin provides essential server management tools for moderators 
 #### `!kick` (Alias: `/kick`)
 Kick a member from the server.
 
-**Permission Required:** `moderation.kick`
+**Permission Required:** `moderation.members.kick`
 
 **Usage:** `!kick <member> [reason]`
 
@@ -30,7 +30,7 @@ Kick a member from the server.
 #### `!ban` (Alias: `/ban`)
 Ban a user from the server with message deletion options.
 
-**Permission Required:** `moderation.ban`
+**Permission Required:** `moderation.members.ban`
 
 **Usage:** `!ban <user> [delete_days] [reason]`
 
@@ -53,7 +53,7 @@ Ban a user from the server with message deletion options.
 #### `!timeout` (Alias: `/timeout`)
 Temporarily timeout a member (Discord timeout feature).
 
-**Permission Required:** `moderation.timeout`
+**Permission Required:** `moderation.members.timeout`
 
 **Usage:** `!timeout <member> <duration_minutes> [reason]`
 
@@ -75,7 +75,7 @@ Temporarily timeout a member (Discord timeout feature).
 #### `!unban` (Alias: `/unban`)
 Remove a ban from a user.
 
-**Permission Required:** `moderation.ban`
+**Permission Required:** `moderation.members.ban`
 
 **Usage:** `!unban <user_id> [reason]`
 
@@ -97,7 +97,7 @@ Remove a ban from a user.
 #### `!purge` (Aliases: `!clear`, `/purge`)
 Delete multiple messages from a channel.
 
-**Permission Required:** `moderation.purge`
+**Permission Required:** `moderation.channels.purge`
 
 **Usage:** 
 - `!purge <amount>` - Delete last N messages
@@ -122,7 +122,7 @@ Delete multiple messages from a channel.
 #### `!slowmode` (Aliases: `!slow`, `/slowmode`)
 Set channel slowmode (rate limiting).
 
-**Permission Required:** `moderation.slowmode`
+**Permission Required:** `moderation.channels.slowmode`
 
 **Usage:**
 - `!slowmode` - Disable slowmode (set to 0)
@@ -148,13 +148,14 @@ Set channel slowmode (rate limiting).
 
 The Moderation plugin defines the following permission nodes:
 
-- `moderation.kick` - Permission to kick members
-- `moderation.ban` - Permission to ban and unban users
-- `moderation.mute` - Permission for muting (reserved for future features)
-- `moderation.warn` - Permission for warning system (reserved for future features)
-- `moderation.purge` - Permission to delete multiple messages
-- `moderation.timeout` - Permission to timeout members
-- `moderation.slowmode` - Permission to manage channel slowmode
+- `moderation.manage` - Grants full access to all moderation commands.
+- `moderation.members.kick` - Permission to kick members
+- `moderation.members.ban` - Permission to ban and unban users
+- `moderation.members.mute` - Permission for muting (reserved for future features)
+- `moderation.members.warn` - Permission for warning system (reserved for future features)
+- `moderation.channels.purge` - Permission to delete multiple messages
+- `moderation.members.timeout` - Permission to timeout members
+- `moderation.channels.slowmode` - Permission to manage channel slowmode
 
 ## Safety Features
 

--- a/plugins/moderation/__init__.py
+++ b/plugins/moderation/__init__.py
@@ -7,13 +7,15 @@ PLUGIN_METADATA = {
     "description": "Moderation commands for server management",
     "dependencies": [],
     "permissions": [
-        "moderation.kick",
-        "moderation.ban",
-        "moderation.mute",
-        "moderation.warn",
-        "moderation.purge",
-        "moderation.timeout",
-        "moderation.slowmode",
+        "moderation.manage",
+        "moderation.members.kick",
+        "moderation.members.ban",
+        "moderation.members.mute",
+        "moderation.members.warn",
+        "moderation.members.timeout",
+        "moderation.members.nickname",
+        "moderation.channels.purge",
+        "moderation.channels.slowmode",
     ],
 }
 

--- a/plugins/moderation/commands/actions.py
+++ b/plugins/moderation/commands/actions.py
@@ -79,7 +79,7 @@ def setup_action_commands(plugin: ModerationPlugin) -> list[Callable[..., Any]]:
     @command(
         name="kick",
         description="Kick a member from the server",
-        permission_node="moderation.kick",
+        permission_node="moderation.members.kick",
     )
     async def kick_member(ctx: lightbulb.Context) -> None:
         member, reason = _extract_member_from_context(ctx)
@@ -160,7 +160,7 @@ def setup_action_commands(plugin: ModerationPlugin) -> list[Callable[..., Any]]:
     @command(
         name="ban",
         description="Ban a member from the server",
-        permission_node="moderation.ban",
+        permission_node="moderation.members.ban",
     )
     async def ban_member(ctx: lightbulb.Context) -> None:
         user_id, user, delete_days, reason = _extract_user_from_context(ctx)
@@ -254,7 +254,7 @@ def setup_action_commands(plugin: ModerationPlugin) -> list[Callable[..., Any]]:
     @command(
         name="timeout",
         description="Timeout a member for a specified duration",
-        permission_node="moderation.timeout",
+        permission_node="moderation.members.timeout",
     )
     async def timeout_member(ctx: lightbulb.Context) -> None:
         member = None
@@ -353,7 +353,7 @@ def setup_action_commands(plugin: ModerationPlugin) -> list[Callable[..., Any]]:
     @command(
         name="unban",
         description="Unban a user from the server",
-        permission_node="moderation.ban",
+        permission_node="moderation.members.ban",
         arguments=[
             CommandArgument("user_id", hikari.OptionType.STRING, "User ID to unban"),
             CommandArgument(
@@ -446,7 +446,7 @@ def setup_action_commands(plugin: ModerationPlugin) -> list[Callable[..., Any]]:
     @command(
         name="nickname",
         description="Change a member's server nickname",
-        permission_node="moderation.nickname",
+        permission_node="moderation.members.nickname",
         arguments=[
             CommandArgument(
                 "member",

--- a/plugins/moderation/commands/channel.py
+++ b/plugins/moderation/commands/channel.py
@@ -35,7 +35,7 @@ def setup_channel_commands(plugin: ModerationPlugin) -> list[Callable[..., Any]]
         name="purge",
         description="Delete multiple messages from a channel",
         aliases=["clear"],
-        permission_node="moderation.purge",
+        permission_node="moderation.channels.purge",
         arguments=[
             CommandArgument(
                 "amount",
@@ -122,7 +122,7 @@ def setup_channel_commands(plugin: ModerationPlugin) -> list[Callable[..., Any]]
         name="slowmode",
         description="Set channel slowmode (rate limit)",
         aliases=["slow"],
-        permission_node="moderation.slowmode",
+        permission_node="moderation.channels.slowmode",
         arguments=[
             CommandArgument(
                 "seconds",
@@ -230,7 +230,7 @@ def setup_channel_commands(plugin: ModerationPlugin) -> list[Callable[..., Any]]
         name="lockdown",
         description="Lock or unlock a channel temporarily",
         aliases=["lock", "unlock"],
-        permission_node="moderation.slowmode",
+        permission_node="moderation.channels.slowmode",
         arguments=[
             CommandArgument(
                 "action",

--- a/plugins/moderation/commands/discipline.py
+++ b/plugins/moderation/commands/discipline.py
@@ -34,7 +34,7 @@ def setup_discipline_commands(plugin: ModerationPlugin) -> list[Callable[..., An
     @command(
         name="warn",
         description="Issue a warning to a member",
-        permission_node="moderation.warn",
+        permission_node="moderation.members.warn",
         arguments=[
             CommandArgument(
                 "member",
@@ -124,7 +124,7 @@ def setup_discipline_commands(plugin: ModerationPlugin) -> list[Callable[..., An
         name="warnings",
         description="View warnings for a member",
         aliases=["warns"],
-        permission_node="moderation.warn",
+        permission_node="moderation.members.warn",
         arguments=[
             CommandArgument(
                 "member",
@@ -194,7 +194,7 @@ def setup_discipline_commands(plugin: ModerationPlugin) -> list[Callable[..., An
     @command(
         name="modnote",
         description="Add or view private moderator notes on users",
-        permission_node="moderation.warn",
+        permission_node="moderation.members.warn",
         arguments=[
             CommandArgument(
                 "action",

--- a/plugins/music/AGENTS.md
+++ b/plugins/music/AGENTS.md
@@ -1,22 +1,91 @@
 # Music Plugin Guidelines
 
-Plugin layout:
+## Overview
+- Feature-rich music system backed by [Lavalink](https://github.com/freyacodes/Lavalink). Supports queue persistence, playback
+  controls, search, history, and per-guild settings.
+- Persists queues and session metadata in the shared database so playback can resume after restarts.
+- Exposes a FastAPI web panel (`/plugin/music`) for queue inspection and management in the browser.
+- Primary permission nodes:
+  - `music.manage` – grants full management (queue/voice/settings) to a role.
+  - `basic.music.playback.control`
+  - `basic.music.queue.view`
+  - `basic.music.queue.control`
+  - `basic.music.voice.control`
+  - `basic.music.search.use`
+  - `music.queue.manage`
+  - `music.voice.manage`
+  - `music.settings.manage`
 
+## Architecture
+- `plugin.py` defines `MusicPlugin` (inherits `DatabaseMixin`, `BasePlugin`, and `WebPanelMixin`). Responsibilities include:
+  - Registering command factories from `commands/`.
+  - Initialising the Lavalink client using host/port/password settings from `config.settings`.
+  - Listening to Hikari voice events and forwarding them to Lavalink.
+  - Restoring persisted queues on startup via `restore_all_queues`.
+- `commands/`
+  - `playback.py` – playback lifecycle (`/play`, `/pause`, `/resume`, `/stop`, `/skip`, `/seek`, `/position`). Uses
+    `basic.music.playback.control`.
+  - `queue.py` – queue viewing, shuffle, loop, and management commands. View/control actions use `basic.music.queue.view` /
+    `basic.music.queue.control`; destructive operations use `music.queue.manage`.
+  - `voice.py` – join/disconnect/volume commands. `basic.music.voice.control` for join/volume, `music.voice.manage` for disconnects.
+  - `search.py` – interactive search with dropdown selection. Requires `basic.music.search.use`.
+  - `nowplaying.py` & `history.py` – informational embeds for current track and history using `basic.music.queue.view`.
+  - `settings.py` – guild-specific settings such as auto-disconnect timer (`music.settings.manage`).
+- `models/__init__.py` defines `MusicQueue` and `MusicSession` for persistence.
+- `events.py` attaches Lavalink event hooks and handles auto-disconnect/queue saving logic.
+- `utils.py` centralises queue persistence, repeat mode handling, and auto-disconnect timers.
+- `web/` supplies FastAPI routes and WebSocket helpers for the control panel. Templates live in `templates/` (Jinja2).
+
+## Commands (Highlights)
+| Command | Description | Permission Node |
+| --- | --- | --- |
+| `/play <query>` | Add a track/playlist to the queue and start playback. | `basic.music.playback.control` |
+| `/pause`, `/resume`, `/stop`, `/skip`, `/seek`, `/position` | Control playback state. | `basic.music.playback.control` |
+| `/queue [page]` | View current queue with pagination. | `basic.music.queue.view` |
+| `/shuffle`, `/loop [mode]` | Non-destructive queue controls. | `basic.music.queue.control` |
+| `/remove <position>`, `/move <from> <to>`, `/clear` | Modify or clear the queue. | `music.queue.manage` |
+| `/join`, `/volume [level]` | Voice channel join and volume adjustments. | `basic.music.voice.control` |
+| `/disconnect` | Disconnect the bot and clear queue. | `music.voice.manage` |
+| `/search <query>` | Interactive search with dropdown results. | `basic.music.search.use` |
+| `/nowplaying`, `/history [page]` | Display currently playing track and history. | `basic.music.queue.view` |
+| `/music-settings [setting] [value]` | Configure per-guild options like auto-disconnect timer. | `music.settings.manage` |
+
+## Configuration
+- Required settings: `lavalink_host`, `lavalink_port`, `lavalink_password` (set in `.env`/`config.settings`).
+- Optional extras: Spotify credentials (if using the Lavalink Spotify plugin) should be configured globally.
+- The auto-disconnect timer is stored per guild via `BasePlugin.get_setting`/`set_setting` under the key `"auto_disconnect_timer"`.
+- Queue persistence writes to the shared database through `MusicQueue`/`MusicSession` models. Ensure migrations run before enabling
+  the plugin.
+
+## Development Guidelines
+- Always obtain the Lavalink player via `self.lavalink_client.player_manager.get(guild_id)` to reuse existing connections.
+- Guard against DM usage – most commands exit early if `ctx.guild_id` is `None`.
+- After editing queue structures call `save_queue_to_db` and broadcast updates using `broadcast_music_update` so the web panel stays
+  in sync.
+- Use `plugin.repeat_modes` for tracking per-guild repeat status (0=off, 1=track, 2=queue).
+- Register new command factories in `_register_commands()` to ensure they are attached on load.
+- When adding new settings, update `settings.py` and persist through the plugin setting helpers.
+- Run targeted tests: `uv run pytest tests/unit/plugins/music` (add coverage as features expand).
+
+## Troubleshooting
+- **Lavalink connection fails**: verify host/port/password match the Lavalink server configuration. The plugin logs connection
+  errors to aid diagnosis.
+- **Bot stays connected to empty voice channels**: check the auto-disconnect timer (`/music-settings auto_disconnect_timer <minutes>`)
+  and ensure `check_voice_channel_empty` is invoked (voice events must reach the bot).
+- **Queue not persisting**: confirm the music tables exist (`MusicQueue`, `MusicSession`) and database writes succeed. Inspect logs for
+  SQL errors.
+- **Search dropdown missing**: Miru must be installed and initialised. If Miru is absent the command falls back to auto-adding the
+  first search result.
+
+## Examples
+### Adjusting the auto-disconnect timer programmatically
+```python
+await plugin.set_setting(ctx.guild_id, "auto_disconnect_timer", 10)  # minutes
 ```
-plugins/music/
-├── commands/
-├── models/
-├── templates/
-├── views/
-└── web/
+
+### Granting queue management rights to DJs
+```python
+# /permission grant @DJs music.queue.manage
 ```
 
-Best practices:
-
-- `plugin.py` houses `MusicPlugin` and is re-exported via `__init__.py`. Keep Lavalink initialisation and command registration here.
-- Database entities (`MusicQueue`, `MusicSession`, …) are in `models/__init__.py`. Export new models through `__all__` and register them from the plugin constructor.
-- UI components live inside the `views` package: interactive Miru views in `views/__init__.py`, while FastAPI panel routes now reside in `web/routes.py`. Import the plugin with `from ..plugin import MusicPlugin` for typing support when needed.
-- Command factory modules inside `commands/` should continue returning decorated callables for `_register_commands()` to attach.
-- Templates for the web panel remain under `templates/`.
-
-Follow repository formatting/lint tooling. Run focused tests with `uv run pytest tests/unit/plugins` (music tests are not yet present) and exercise integration manually when touching playback/web behaviour.
+Follow these guidelines to keep new music features robust, performant, and in sync with the rest of the framework.

--- a/plugins/music/__init__.py
+++ b/plugins/music/__init__.py
@@ -8,7 +8,17 @@ PLUGIN_METADATA = {
         "Advanced music bot with persistent queues, interactive controls, search selection, "
         "playlist support, queue management, auto-disconnect, and music history tracking"
     ),
-    "permissions": ["music.play", "music.manage", "music.settings"],
+    "permissions": [
+        "music.manage",
+        "basic.music.playback.control",
+        "basic.music.queue.view",
+        "basic.music.queue.control",
+        "basic.music.voice.control",
+        "basic.music.search.use",
+        "music.queue.manage",
+        "music.voice.manage",
+        "music.settings.manage",
+    ],
 }
 
 __all__ = ["MusicPlugin"]

--- a/plugins/music/commands/history.py
+++ b/plugins/music/commands/history.py
@@ -15,7 +15,7 @@ def setup_history_commands(plugin):
         name="history",
         description="Show recently played tracks",
         aliases=["recent"],
-        permission_node="basic.music.play",
+        permission_node="basic.music.queue.view",
         arguments=[
             CommandArgument("page", hikari.OptionType.INTEGER, "Page number (shows 5 tracks per page)", required=False, default=1)
         ],

--- a/plugins/music/commands/nowplaying.py
+++ b/plugins/music/commands/nowplaying.py
@@ -13,7 +13,7 @@ def setup_nowplaying_commands(plugin):
         name="nowplaying",
         description="Show the currently playing track with detailed information",
         aliases=["np", "current"],
-        permission_node="basic.music.play",
+        permission_node="basic.music.queue.view",
     )
     async def now_playing(ctx: lightbulb.Context) -> None:
         if not ctx.guild_id:

--- a/plugins/music/commands/playback.py
+++ b/plugins/music/commands/playback.py
@@ -23,7 +23,7 @@ def setup_playback_commands(plugin):
     @command(
         name="play",
         description="Play a song",
-        permission_node="basic.music.play",
+        permission_node="basic.music.playback.control",
         aliases=["p"],
         arguments=[CommandArgument("query", hikari.OptionType.STRING, "Song name or URL to play")],
     )
@@ -133,7 +133,7 @@ def setup_playback_commands(plugin):
     @command(
         name="pause",
         description="Pause the current track",
-        permission_node="basic.music.play",
+        permission_node="basic.music.playback.control",
     )
     async def pause(ctx: lightbulb.Context) -> None:
         if not ctx.guild_id:
@@ -161,7 +161,7 @@ def setup_playback_commands(plugin):
     @command(
         name="resume",
         description="Resume the current track",
-        permission_node="basic.music.play",
+        permission_node="basic.music.playback.control",
     )
     async def resume(ctx: lightbulb.Context) -> None:
         if not ctx.guild_id:
@@ -191,7 +191,7 @@ def setup_playback_commands(plugin):
     @command(
         name="stop",
         description="Stop the music and clear the queue",
-        permission_node="basic.music.play",
+        permission_node="basic.music.playback.control",
     )
     async def stop(ctx: lightbulb.Context) -> None:
         if not ctx.guild_id:
@@ -223,7 +223,7 @@ def setup_playback_commands(plugin):
     @command(
         name="skip",
         description="Skip the current track",
-        permission_node="basic.music.play",
+        permission_node="basic.music.playback.control",
     )
     async def skip(ctx: lightbulb.Context) -> None:
         if not ctx.guild_id:
@@ -310,7 +310,7 @@ def setup_playback_commands(plugin):
     @command(
         name="seek",
         description="Seek to a specific position in the track (format: mm:ss or seconds)",
-        permission_node="basic.music.play",
+        permission_node="basic.music.playback.control",
         arguments=[CommandArgument("position", hikari.OptionType.STRING, "Position to seek to (mm:ss or seconds)")],
     )
     async def seek(ctx: lightbulb.Context, position: str) -> None:
@@ -356,7 +356,7 @@ def setup_playback_commands(plugin):
     @command(
         name="position",
         description="Show current position in the track",
-        permission_node="basic.music.play",
+        permission_node="basic.music.playback.control",
     )
     async def position(ctx: lightbulb.Context) -> None:
         if not ctx.guild_id:

--- a/plugins/music/commands/queue.py
+++ b/plugins/music/commands/queue.py
@@ -26,7 +26,7 @@ def setup_queue_commands(plugin):
         name="queue",
         description="Show the current queue with detailed information",
         aliases=["q"],
-        permission_node="basic.music.play",
+        permission_node="basic.music.queue.view",
         arguments=[
             CommandArgument("page", hikari.OptionType.INTEGER, "Page number (shows 5 tracks per page)", required=False, default=1)
         ],
@@ -137,7 +137,7 @@ def setup_queue_commands(plugin):
     @command(
         name="shuffle",
         description="Shuffle the current queue",
-        permission_node="basic.music.play",
+        permission_node="basic.music.queue.control",
     )
     async def shuffle(ctx: lightbulb.Context) -> None:
         if not ctx.guild_id:
@@ -175,7 +175,7 @@ def setup_queue_commands(plugin):
         name="loop",
         description="Toggle loop modes: off -> track -> queue -> off",
         aliases=["repeat"],
-        permission_node="basic.music.play",
+        permission_node="basic.music.queue.control",
         arguments=[CommandArgument("mode", hikari.OptionType.STRING, "Loop mode: off, track, or queue", required=False)],
     )
     async def loop(ctx: lightbulb.Context, mode: str = None) -> None:
@@ -219,7 +219,7 @@ def setup_queue_commands(plugin):
         name="remove",
         description="Remove a track from the queue by position",
         aliases=["rm"],
-        permission_node="moderation.music.manage",
+        permission_node="music.queue.manage",
         arguments=[CommandArgument("position", hikari.OptionType.INTEGER, "Position in queue to remove (1-based)")],
     )
     async def remove_track(ctx: lightbulb.Context, position: int) -> None:
@@ -265,7 +265,7 @@ def setup_queue_commands(plugin):
     @command(
         name="move",
         description="Move a track to a different position in the queue",
-        permission_node="moderation.music.manage",
+        permission_node="music.queue.manage",
         arguments=[
             CommandArgument("from_position", hikari.OptionType.INTEGER, "Current position of track (1-based)"),
             CommandArgument("to_position", hikari.OptionType.INTEGER, "New position for track (1-based)"),
@@ -322,7 +322,7 @@ def setup_queue_commands(plugin):
     @command(
         name="clear",
         description="Clear the queue (keeps currently playing track)",
-        permission_node="moderation.music.manage",
+        permission_node="music.queue.manage",
     )
     async def clear_queue(ctx: lightbulb.Context) -> None:
         if not ctx.guild_id:

--- a/plugins/music/commands/search.py
+++ b/plugins/music/commands/search.py
@@ -16,7 +16,7 @@ def setup_search_commands(plugin):
     @command(
         name="search",
         description="Search for tracks and choose from multiple results",
-        permission_node="basic.music.play",
+        permission_node="basic.music.search.use",
         arguments=[CommandArgument("query", hikari.OptionType.STRING, "Song name or artist to search for")],
     )
     async def search_tracks(ctx: lightbulb.Context, query: str) -> None:

--- a/plugins/music/commands/settings.py
+++ b/plugins/music/commands/settings.py
@@ -11,7 +11,7 @@ def setup_settings_commands(plugin):
         name="music-settings",
         description="Configure music plugin settings",
         aliases=["msettings"],
-        permission_node="admin.music.settings",
+        permission_node="music.settings.manage",
         arguments=[
             CommandArgument("setting", hikari.OptionType.STRING, "Setting to configure: auto_disconnect_timer", required=False),
             CommandArgument("value", hikari.OptionType.INTEGER, "Value for the setting (1-30 minutes for timer)", required=False),

--- a/plugins/music/commands/voice.py
+++ b/plugins/music/commands/voice.py
@@ -23,7 +23,7 @@ def setup_voice_commands(plugin):
     @command(
         name="join",
         description="Join your voice channel",
-        permission_node="basic.music.play",
+        permission_node="basic.music.voice.control",
     )
     async def join_voice(ctx: lightbulb.Context) -> None:
         if not ctx.guild_id:
@@ -61,7 +61,7 @@ def setup_voice_commands(plugin):
         name="disconnect",
         description="Disconnect from voice channel",
         aliases=["leave"],
-        permission_node="moderation.music.manage",
+        permission_node="music.voice.manage",
     )
     async def disconnect(ctx: lightbulb.Context) -> None:
         if not ctx.guild_id:
@@ -97,7 +97,7 @@ def setup_voice_commands(plugin):
     @command(
         name="volume",
         description="Set or check the volume (0-100)",
-        permission_node="basic.music.play",
+        permission_node="basic.music.voice.control",
         arguments=[CommandArgument("level", hikari.OptionType.INTEGER, "Volume level (0-100)", required=False)],
     )
     async def volume(ctx: lightbulb.Context, level: int = None) -> None:

--- a/plugins/utility/AGENTS.md
+++ b/plugins/utility/AGENTS.md
@@ -1,21 +1,72 @@
 # Utility Plugin Guidelines
 
-Shared layout:
+## Overview
+- Collection of practical utilities: user/server info, weather, QR codes, reminders, polls, timestamp conversions, color analysis,
+  and text transformations.
+- Maintains an `aiohttp.ClientSession` for external HTTP requests (weather, “On This Day” data) with graceful degradation.
+- Primary permission nodes:
+  - `basic.utility.info.view`
+  - `basic.utility.convert.use`
+  - `basic.utility.tools.use`
 
+## Architecture
+- `plugin.py` defines `UtilityPlugin`, creates the shared HTTP session in `on_load`, and registers command factories.
+- `commands/`
+  - `info.py` – guild/user info, avatar retrieval, weather lookup. Uses `basic.utility.info.view`.
+  - `convert.py` – timestamp formatting, base64 encode/decode, color info, hashing, translation helpers. Uses a mix of
+    `basic.utility.convert.use` and `basic.utility.tools.use` depending on functionality.
+  - `tools.py` – reminders, polls, QR code generation, “On This Day” history, countdown timers. Uses `basic.utility.tools.use`.
+- `config.py` centralises constants (API endpoints, colours, limits) for commands to import.
+- `utils.py` exposes helper functions (e.g., `parse_timestamp_input`, `rgb_to_hsl`).
+- Web/template directories are placeholders for future web panel functionality.
+
+## Commands (Highlights)
+| Command | Description | Permission Node |
+| --- | --- | --- |
+| `/userinfo [user]` | Rich user profile embed including roles and key permissions. | `basic.utility.info.view` |
+| `/avatar [user]` | High resolution avatar viewer. | `basic.utility.info.view` |
+| `/weather <location>` | Weather summary using wttr.in API. | `basic.utility.info.view` |
+| `/timestamp [input]` | Converts time into Discord timestamp formats. | `basic.utility.convert.use` |
+| `/base64 <encode|decode> <text>` | Base64 conversion helper. | `basic.utility.convert.use` |
+| `/color <value>` | Displays color information from hex/name. | `basic.utility.tools.use` |
+| `/qr <text>` | Generates a QR code using quickchart.io. | `basic.utility.tools.use` |
+| `/remind <time> <message>` | Creates a reminder with background task scheduling. | `basic.utility.tools.use` |
+| `/poll <question> [options...]` | Quick reaction poll creation. | `basic.utility.tools.use` |
+| `/onthisday <date|relative>` | Historical facts for the supplied date. | `basic.utility.tools.use` |
+
+## Configuration
+- `config.py` contains numerous constants:
+  - API endpoints (`API_ENDPOINTS`) for jokes, memes, weather, QR codes, etc.
+  - Embed colours (`INFO_COLOR`, `ERROR_COLOR`, `POLL_COLOR`, etc.).
+  - Limits (e.g., `QR_TEXT_LIMIT`, `REMINDER_MAX_DURATION`).
+- No environment variables; relies on the global bot settings for tokens and HTTP proxies if needed.
+- Commands gracefully degrade when `plugin.session` is `None` by using fallback data or aborting with helpful errors.
+
+## Development Guidelines
+- Use the shared `plugin.session` for outbound HTTP calls and guard with `if not plugin.session: ...` as existing commands do.
+- Wrap long-running background tasks (e.g., reminders) with appropriate cleanup to avoid leaving stray tasks on unload.
+- Share embed styling via `plugin.create_embed` and reuse colour constants from `config.py`.
+- Validate all user input (time formats, URLs, number ranges). Many helper functions already exist in `utils.py` and `config.py`.
+- Register new commands through the factory modules and update tests in `tests/unit/plugins/utility`.
+
+## Troubleshooting
+- **HTTP dependent commands failing**: check network connectivity and API availability. Many commands already catch exceptions and
+  fall back to built-in datasets.
+- **Reminders not firing**: ensure the bot process remains running; reminders rely on in-memory tasks, not persistent jobs.
+- **Color or timestamp parsing errors**: review `utils.py` helpers and update validation to cover new formats.
+
+## Examples
+### Adding a custom conversion command
+```python
+@command(name="slugify", description="Convert text to URL-friendly slug", permission_node="basic.utility.convert.use")
+async def slugify(ctx: lightbulb.Context, text: str) -> None:
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    await ctx.respond(f"`{slug}`")
 ```
-plugins/utility/
-├── commands/
-├── models/
-├── templates/
-├── views/
-└── web/
+
+### Scheduling a reminder from another plugin
+```python
+await plugin.bot.reminder_manager.schedule(ctx.guild_id, ctx.author.id, "Check the raid", delay=3600)
 ```
 
-Recommendations:
-
-- `plugin.py` exports `UtilityPlugin` (via `__init__.py`). Keep aiohttp session management and command registration here.
-- Command factory modules in `commands/` should continue returning decorated callables; `_register_commands()` attaches them.
-- Place future Miru components under `views/` and new persistence models under `models/`.
-- The templates directory is ready for any future web panel assets, and `web/` should hold FastAPI routes when needed.
-
-Respect repository-wide lint/format tooling. Run `uv run pytest tests/unit/plugins/utility` when altering behaviour.
+Keep new utilities consistent with these patterns to maintain reliability across the toolset.

--- a/plugins/utility/__init__.py
+++ b/plugins/utility/__init__.py
@@ -5,7 +5,11 @@ PLUGIN_METADATA = {
     "version": "1.0.0",
     "author": "Bot Framework",
     "description": "Useful utility commands for various tasks including user info, timestamps, color tools, and text conversion",
-    "permissions": ["basic.tools", "basic.info", "basic.convert"],
+    "permissions": [
+        "basic.utility.tools.use",
+        "basic.utility.info.view",
+        "basic.utility.convert.use",
+    ],
 }
 
 __all__ = ["UtilityPlugin"]

--- a/plugins/utility/commands/convert.py
+++ b/plugins/utility/commands/convert.py
@@ -38,7 +38,7 @@ def setup_convert_commands(plugin: UtilityPlugin) -> list[Callable[..., Any]]:
         name="timestamp",
         description="Convert time to Discord timestamp formats",
         aliases=["time", "ts"],
-        permission_node="basic.convert",
+        permission_node="basic.utility.convert.use",
         arguments=[
             CommandArgument(
                 "time_input",
@@ -101,7 +101,7 @@ def setup_convert_commands(plugin: UtilityPlugin) -> list[Callable[..., Any]]:
         name="color",
         description="Display information about a color",
         aliases=["colour"],
-        permission_node="basic.tools",
+        permission_node="basic.utility.tools.use",
         arguments=[
             CommandArgument(
                 "color_input",
@@ -168,7 +168,7 @@ def setup_convert_commands(plugin: UtilityPlugin) -> list[Callable[..., Any]]:
         name="base64",
         description="Encode or decode base64 text",
         aliases=["b64"],
-        permission_node="basic.convert",
+        permission_node="basic.utility.convert.use",
         arguments=[
             CommandArgument("action", hikari.OptionType.STRING, "encode or decode"),
             CommandArgument("text", hikari.OptionType.STRING, "Text to encode/decode"),
@@ -226,7 +226,7 @@ def setup_convert_commands(plugin: UtilityPlugin) -> list[Callable[..., Any]]:
     @command(
         name="hash",
         description="Generate hash of text (MD5, SHA1, SHA256)",
-        permission_node="basic.tools",
+        permission_node="basic.utility.tools.use",
         arguments=[
             CommandArgument(
                 "algorithm",
@@ -275,7 +275,7 @@ def setup_convert_commands(plugin: UtilityPlugin) -> list[Callable[..., Any]]:
         name="translate",
         description="Translate text to different languages",
         aliases=["tr"],
-        permission_node="basic.convert",
+        permission_node="basic.utility.convert.use",
         arguments=[
             CommandArgument(
                 "target_language",

--- a/plugins/utility/commands/info.py
+++ b/plugins/utility/commands/info.py
@@ -24,7 +24,7 @@ def setup_info_commands(plugin: UtilityPlugin) -> list[Callable[..., Any]]:
         name="userinfo",
         description="Get detailed information about a user",
         aliases=["user", "whois"],
-        permission_node="basic.info",
+        permission_node="basic.utility.info.view",
         arguments=[
             CommandArgument(
                 "user",
@@ -112,7 +112,7 @@ def setup_info_commands(plugin: UtilityPlugin) -> list[Callable[..., Any]]:
         name="avatar",
         description="Get a user's avatar in high resolution",
         aliases=["av", "pfp"],
-        permission_node="basic.info",
+        permission_node="basic.utility.info.view",
         arguments=[CommandArgument("user", hikari.OptionType.USER, "User to get avatar of", required=False)],
     )
     async def avatar(ctx: lightbulb.Context, user: hikari.User | None = None) -> None:
@@ -145,7 +145,7 @@ def setup_info_commands(plugin: UtilityPlugin) -> list[Callable[..., Any]]:
     @command(
         name="weather",
         description="Get weather information for a location",
-        permission_node="basic.info",
+        permission_node="basic.utility.info.view",
         arguments=[
             CommandArgument(
                 "location",

--- a/plugins/utility/commands/tools.py
+++ b/plugins/utility/commands/tools.py
@@ -35,7 +35,7 @@ def setup_tool_commands(plugin: UtilityPlugin) -> list[Callable[..., Any]]:
         name="onthisday",
         description="Show historical events for a date (timedelta or dd/mm/yyyy)",
         aliases=["otd", "history"],
-        permission_node="basic.tools",
+        permission_node="basic.utility.tools.use",
         arguments=[
             CommandArgument(
                 "date",
@@ -180,7 +180,7 @@ def setup_tool_commands(plugin: UtilityPlugin) -> list[Callable[..., Any]]:
         name="qr",
         description="Generate a QR code from text or URL",
         aliases=["qrcode"],
-        permission_node="basic.tools",
+        permission_node="basic.utility.tools.use",
         arguments=[
             CommandArgument(
                 "text",
@@ -233,7 +233,7 @@ def setup_tool_commands(plugin: UtilityPlugin) -> list[Callable[..., Any]]:
     @command(
         name="poll",
         description="Create a reaction-based poll",
-        permission_node="basic.tools",
+        permission_node="basic.utility.tools.use",
         arguments=[
             CommandArgument("question", hikari.OptionType.STRING, "The poll question"),
             CommandArgument("option1", hikari.OptionType.STRING, "First option"),

--- a/tests/unit/plugins/moderation/test_moderation_plugin.py
+++ b/tests/unit/plugins/moderation/test_moderation_plugin.py
@@ -254,9 +254,10 @@ class TestModerationPluginMetadata:
         """Test plugin metadata structure."""
         assert PLUGIN_METADATA["name"] == "Moderation"
         assert PLUGIN_METADATA["version"] == "1.0.0"
-        assert "moderation.kick" in PLUGIN_METADATA["permissions"]
-        assert "moderation.ban" in PLUGIN_METADATA["permissions"]
-        assert "moderation.timeout" in PLUGIN_METADATA["permissions"]
+        assert "moderation.manage" in PLUGIN_METADATA["permissions"]
+        assert "moderation.members.kick" in PLUGIN_METADATA["permissions"]
+        assert "moderation.members.ban" in PLUGIN_METADATA["permissions"]
+        assert "moderation.members.timeout" in PLUGIN_METADATA["permissions"]
 
 
 class TestKickMemberExtended:


### PR DESCRIPTION
## Summary
- Align plugin metadata and command decorators with the unified permission naming scheme, adding plugin-level aggregators and explicit `basic.` nodes where appropriate.
- Update `PermissionManager` to ingest metadata-defined permissions, streamline default handling, and honor `.manage`/`.admin` inheritance patterns.
- Refresh documentation (README, plugin AGENTS, permission audit/migration guides) to describe the updated hierarchy and migration steps.

## Testing
- DISCORD_TOKEN=test WEB_SECRET_KEY=test uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d291538b1083279db442f25dd76c92