### PR TITLE
fix(admin): use make_icon_url() instead of icon_url on GatewayGuild

### DIFF
--- a/plugins/admin/web/routes.py
+++ b/plugins/admin/web/routes.py
@@ -188,10 +188,11 @@ def register_admin_routes(app: FastAPI, plugin: "AdminPlugin") -> None:
             if plugin.cache:
                 cached = plugin.cache.get_guild(guild_id)
                 if cached:
+                    icon_url = cached.make_icon_url()
                     bot_guild_info = {
                         "id": str(cached.id),
                         "name": cached.name,
-                        "icon": str(cached.icon_url) if cached.icon_url else None,
+                        "icon": str(icon_url) if icon_url else None,
                     }
 
             return JSONResponse({"success": True, "guild_info": bot_guild_info or guild_info})


### PR DESCRIPTION
hikari's GatewayGuild exposes make_icon_url() not icon_url; the attribute access was raising AttributeError and returning 500 on every check-access call.

https://claude.ai/code/session_01KhPQdhBVbUFL8VH8pFLzdS