### PR TITLE
Fix angle command image attachment for prefix commands

### DIFF
--- a/plugins/games/commands/angle.py
+++ b/plugins/games/commands/angle.py
@@ -48,18 +48,19 @@ def setup_angle_commands(plugin: GamesPlugin) -> list[Callable[..., Any]]:
             user_mention = ctx.author.mention
             embed = _build_angle_embed(plugin, state, user_mention)
             attachment = hikari.Bytes(image_bytes, "angle.png")
+            embed.set_image(attachment)
 
             miru_client = getattr(plugin.bot, "miru_client", None)
 
             if is_complete:
                 # Game already finished — just show the result, no button
-                await ctx.respond(embed=embed, attachments=[attachment])
+                await ctx.respond(embed=embed)
             elif miru_client:
                 view = AngleView(plugin, ctx.author.id, ctx.guild_id, state)
-                response = await ctx.respond(embed=embed, attachments=[attachment], components=view)
+                response = await ctx.respond(embed=embed, components=view)
                 miru_client.start_view(view, bind_to=response)
             else:
-                await ctx.respond(embed=embed, attachments=[attachment])
+                await ctx.respond(embed=embed)
 
             await plugin.log_command_usage(ctx, "angle", True)
 

--- a/plugins/games/views/angle.py
+++ b/plugins/games/views/angle.py
@@ -91,7 +91,6 @@ def _build_angle_embed(plugin: GamesPlugin, state: dict[str, Any], user_mention:
             remaining_text += " *(no points — already played today)*"
         embed.set_footer(remaining_text)
 
-    embed.set_image("attachment://angle.png")
     return embed
 
 
@@ -147,12 +146,12 @@ class AngleGuessModal(miru.Modal, title="Guess the Angle"):
             new_view = AngleView(self.plugin, self.user_id, self.guild_id, state)
 
         attachment = hikari.Bytes(image_bytes, "angle.png")
+        embed.set_image(attachment)
 
         try:
             if new_view:
                 await self.angle_view.message.edit(
                     embed=embed,
-                    attachments=[attachment],
                     components=new_view,
                 )
                 # Re-bind the new view so its button works
@@ -162,7 +161,6 @@ class AngleGuessModal(miru.Modal, title="Guess the Angle"):
             else:
                 await self.angle_view.message.edit(
                     embed=embed,
-                    attachments=[attachment],
                     components=[],
                 )
             # Acknowledge the modal interaction silently


### PR DESCRIPTION
hikari's serialize_embed only treats http/https strings as web resources; 'attachment://angle.png' was treated as a file path, causing FileNotFoundError. Fix by passing hikari.Bytes directly to embed.set_image() so hikari serializes the bytes as a proper upload, which works for both slash and prefix commands.

https://claude.ai/code/session_015FY8CBbSeb6kHuyJJ5MMfR