### PR TITLE
Fix angle game: NoneType error, static target image, no distance hints

### DIFF
--- a/plugins/games/commands/angle.py
+++ b/plugins/games/commands/angle.py
@@ -42,8 +42,7 @@ def setup_angle_commands(plugin: GamesPlugin) -> list[Callable[..., Any]]:
             state = await plugin.get_or_create_angle_game(ctx.author.id, ctx.guild_id)
 
             is_complete = state.get("is_complete", False)
-            target_reveal = state["target"] if is_complete else None
-            image_bytes = generate_angle_image(state["guesses"], target=target_reveal)
+            image_bytes = generate_angle_image(state["target"])
 
             user_mention = ctx.author.mention
             embed = _build_angle_embed(plugin, state, user_mention)

--- a/plugins/games/plugin.py
+++ b/plugins/games/plugin.py
@@ -422,7 +422,17 @@ class GamesPlugin(DatabaseMixin, BasePlugin):
                 )
                 stats = stats_result.scalars().first()
                 if not stats:
-                    stats = AngleStats(user_id=user_id, guild_id=guild_id)
+                    stats = AngleStats(
+                        user_id=user_id,
+                        guild_id=guild_id,
+                        total_games=0,
+                        wins=0,
+                        total_points=0,
+                        exact_wins=0,
+                        close_wins=0,
+                        current_win_streak=0,
+                        best_win_streak=0,
+                    )
                     session.add(stats)
 
                 stats.total_games += 1

--- a/plugins/games/utils/angle_image.py
+++ b/plugins/games/utils/angle_image.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import io
 
 import matplotlib
-import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -13,25 +12,19 @@ matplotlib.use("Agg")  # non-interactive backend
 # Discord dark theme palette
 BG_COLOR = "#2b2d31"
 CIRCLE_COLOR = "#5865f2"  # Discord blurple
-REF_COLOR = "#ffffff"
-GUESS_COLORS = ["#faa61a", "#eb459e", "#ed4245", "#3ba55c"]  # yellow, pink, red, green
-TARGET_COLOR = "#57f287"  # Discord green
+TARGET_COLOR = "#faa61a"  # gold — the mystery ray
 TEXT_COLOR = "#dcddde"
 GRID_COLOR = "#40444b"
 
 
-def generate_angle_image(
-    guesses: list[int],
-    target: int | None = None,
-    max_attempts: int = 4,
-) -> bytes:
+def generate_angle_image(target: int) -> bytes:
     """
-    Render a protractor image showing each guess as a labeled ray.
+    Render a protractor showing the mystery angle as an unlabeled ray.
+
+    The user must visually estimate the angle and submit their numeric guess.
 
     Args:
-        guesses: List of angle guesses (degrees, 0-360).
-        target: The correct answer; only drawn when the game is over (not None).
-        max_attempts: Total allowed attempts (for legend spacing).
+        target: The correct angle (degrees, 0-360). Drawn without a degree label.
 
     Returns:
         PNG image bytes.
@@ -76,60 +69,31 @@ def generate_angle_image(
                 color=GRID_COLOR, linewidth=0.8, linestyle="--", alpha=0.5)
 
     # --- reference dot at origin ---
-    ax.plot(0, 0, "o", color=REF_COLOR, markersize=5, zorder=5)
+    ax.plot(0, 0, "o", color=TEXT_COLOR, markersize=5, zorder=5)
 
-    # --- draw each guess ray ---
-    legend_handles = []
-    for i, guess in enumerate(guesses):
-        color = GUESS_COLORS[i % len(GUESS_COLORS)]
-        rad = np.radians(guess)
-        tip_x, tip_y = 0.85 * np.cos(rad), 0.85 * np.sin(rad)
-        ax.annotate(
-            "",
-            xy=(tip_x, tip_y),
-            xytext=(0, 0),
-            arrowprops=dict(
-                arrowstyle="-|>",
-                color=color,
-                lw=2.2,
-                mutation_scale=16,
-            ),
-            zorder=6,
-        )
-        label = f"#{i + 1}: {guess}°"
-        legend_handles.append(mpatches.Patch(color=color, label=label))
+    # --- mystery target ray (no degree label) ---
+    rad = np.radians(target)
+    tip_x, tip_y = 0.88 * np.cos(rad), 0.88 * np.sin(rad)
+    ax.annotate(
+        "",
+        xy=(tip_x, tip_y),
+        xytext=(0, 0),
+        arrowprops=dict(
+            arrowstyle="-|>",
+            color=TARGET_COLOR,
+            lw=2.8,
+            mutation_scale=18,
+        ),
+        zorder=7,
+    )
 
-    # --- draw target ray (only when game is over) ---
-    if target is not None:
-        rad = np.radians(target)
-        tip_x, tip_y = 0.88 * np.cos(rad), 0.88 * np.sin(rad)
-        ax.annotate(
-            "",
-            xy=(tip_x, tip_y),
-            xytext=(0, 0),
-            arrowprops=dict(
-                arrowstyle="-|>",
-                color=TARGET_COLOR,
-                lw=2.8,
-                mutation_scale=18,
-            ),
-            zorder=7,
-        )
-        legend_handles.append(mpatches.Patch(color=TARGET_COLOR, label=f"Answer: {target}°"))
-
-    # --- legend ---
-    if legend_handles:
-        legend = ax.legend(
-            handles=legend_handles,
-            loc="lower center",
-            bbox_to_anchor=(0.5, -0.08),
-            ncol=min(len(legend_handles), 3),
-            framealpha=0.0,
-            fontsize=9,
-            labelcolor=TEXT_COLOR,
-        )
-        for text in legend.get_texts():
-            text.set_fontfamily("monospace")
+    # --- prompt label ---
+    ax.text(
+        0, -1.42,
+        "What angle is this?",
+        ha="center", va="center",
+        fontsize=9, color=TEXT_COLOR, fontfamily="monospace",
+    )
 
     plt.tight_layout(pad=0.2)
 

--- a/plugins/games/views/angle.py
+++ b/plugins/games/views/angle.py
@@ -49,15 +49,9 @@ def _build_angle_embed(plugin: GamesPlugin, state: dict[str, Any], user_mention:
 
         if dist == 0:
             feedback = "✅ **Exact!**"
-        elif dist == 1:
-            arrow = "⬆️" if direction == "higher" else "⬇️"
-            feedback = f"{arrow} **{dist}° off** — go {direction}"
-        elif dist == 2:
-            arrow = "⬆️" if direction == "higher" else "⬇️"
-            feedback = f"{arrow} **{dist}° off** — go {direction}"
         else:
             arrow = "⬆️" if direction == "higher" else "⬇️"
-            feedback = f"{arrow} {dist}° off — go {direction}"
+            feedback = f"{arrow} Go {direction}"
 
         history_lines.append(f"{color_dot} Guess #{i + 1}: **{guess}°** — {feedback}")
 
@@ -133,20 +127,16 @@ class AngleGuessModal(miru.Modal, title="Guess the Angle"):
 
         is_complete = state.get("is_complete", False)
 
-        # Generate image (reveal target only when game over)
-        target_reveal = state["target"] if is_complete else None
-        image_bytes = generate_angle_image(state["guesses"], target=target_reveal)
+        image_bytes = generate_angle_image(state["target"])
 
         user_mention = f"<@{self.user_id}>"
         embed = _build_angle_embed(self.plugin, state, user_mention)
+        embed.set_image(hikari.Bytes(image_bytes, "angle.png"))
 
         # Build the updated view (remove button if game over)
         new_view: AngleView | None = None
         if not is_complete:
             new_view = AngleView(self.plugin, self.user_id, self.guild_id, state)
-
-        attachment = hikari.Bytes(image_bytes, "angle.png")
-        embed.set_image(attachment)
 
         try:
             if new_view:


### PR DESCRIPTION
- Fix AngleStats NoneType +=: pass explicit zeros on creation since SQLAlchemy column defaults aren't reflected in Python objects before flush
- Redesign image: show only the mystery target angle ray (unlabeled), matching angle.wtf style — image is now fixed for the whole game
- Remove degree distance from guess feedback (was giving too much away); now only shows higher/lower direction arrow
- Simplify generate_angle_image() to take target only (no guesses)

https://claude.ai/code/session_015FY8CBbSeb6kHuyJJ5MMfR