### PR TITLE
Add achievements for Angle/RPS games and Games web panel

### DIFF
--- a/plugins/games/commands/rps.py
+++ b/plugins/games/commands/rps.py
@@ -35,9 +35,10 @@ def setup_rps_commands(plugin: GamesPlugin) -> list[Callable[..., Any]]:
                 color=hikari.Color(EMBED_COLORS["rps"]),
             )
 
+            guild_id = ctx.guild_id or 0
             miru_client = getattr(plugin.bot, "miru_client", None)
             if miru_client:
-                view = RPSView(plugin, ctx.author.id)
+                view = RPSView(plugin, ctx.author.id, guild_id)
                 response = await ctx.respond(embed=embed, components=view)
                 miru_client.start_view(view, bind_to=response)
             else:

--- a/plugins/games/config.py
+++ b/plugins/games/config.py
@@ -228,3 +228,101 @@ ANGLE_POINTS = {
     "close": 75,    # 1° off
     "near": 50,     # 2° off
 }
+
+# Angle achievement definitions
+ANGLE_ACHIEVEMENTS = {
+    "angle_first_win": {
+        "name": "Bullseye!",
+        "description": "Win your first angle game",
+        "emoji": "🎯",
+        "requirement": {"type": "wins", "value": 1},
+    },
+    "angle_sharpshooter": {
+        "name": "Sharpshooter",
+        "description": "Get an exact guess (0° off) for the first time",
+        "emoji": "🏹",
+        "requirement": {"type": "exact_wins", "value": 1},
+    },
+    "angle_precision": {
+        "name": "Precision Master",
+        "description": "Get 10 exact wins (0° off)",
+        "emoji": "🔭",
+        "requirement": {"type": "exact_wins", "value": 10},
+    },
+    "angle_veteran": {
+        "name": "Angle Veteran",
+        "description": "Play 30 angle games",
+        "emoji": "📐",
+        "requirement": {"type": "total_games", "value": 30},
+    },
+    "angle_streak": {
+        "name": "On a Roll",
+        "description": "Win 5 angle games in a row",
+        "emoji": "🔥",
+        "requirement": {"type": "win_streak", "value": 5},
+    },
+    "angle_collector": {
+        "name": "Point Collector",
+        "description": "Earn 500 angle points",
+        "emoji": "💎",
+        "requirement": {"type": "total_points", "value": 500},
+    },
+    "angle_close_enough": {
+        "name": "Close Enough",
+        "description": "Win 10 games within 2° of the target",
+        "emoji": "🎪",
+        "requirement": {"type": "close_wins", "value": 10},
+    },
+}
+
+# RPS achievement definitions
+RPS_ACHIEVEMENTS = {
+    "rps_first_win": {
+        "name": "First Blood",
+        "description": "Win your first RPS game",
+        "emoji": "✊",
+        "requirement": {"type": "wins", "value": 1},
+    },
+    "rps_veteran": {
+        "name": "RPS Veteran",
+        "description": "Play 50 RPS games",
+        "emoji": "🎮",
+        "requirement": {"type": "total_games", "value": 50},
+    },
+    "rps_champion": {
+        "name": "RPS Champion",
+        "description": "Win 25 RPS games",
+        "emoji": "🏆",
+        "requirement": {"type": "wins", "value": 25},
+    },
+    "rps_streak": {
+        "name": "Unstoppable",
+        "description": "Win 5 RPS games in a row",
+        "emoji": "⚡",
+        "requirement": {"type": "win_streak", "value": 5},
+    },
+    "rps_rock_solid": {
+        "name": "Rock Solid",
+        "description": "Win 20 games with Rock",
+        "emoji": "🪨",
+        "requirement": {"type": "rock_wins", "value": 20},
+    },
+    "rps_paper_trail": {
+        "name": "Paper Trail",
+        "description": "Win 20 games with Paper",
+        "emoji": "📄",
+        "requirement": {"type": "paper_wins", "value": 20},
+    },
+    "rps_scissor_happy": {
+        "name": "Scissor Happy",
+        "description": "Win 20 games with Scissors",
+        "emoji": "✂️",
+        "requirement": {"type": "scissors_wins", "value": 20},
+    },
+    "rps_draw_master": {
+        "name": "Draw Master",
+        "description": "Draw 15 RPS games",
+        "emoji": "🤝",
+        "requirement": {"type": "draws", "value": 15},
+    },
+}

--- a/plugins/games/models/__init__.py
+++ b/plugins/games/models/__init__.py
@@ -1,7 +1,9 @@
-from .angle import AngleGame, AngleStats
+from .angle import AngleAchievement, AngleGame, AngleStats
+from .rps import RPSAchievement, RPSStats
 from .trivia import CustomQuestion, GuildLeaderboard, TriviaAchievement, TriviaStats
 
 __all__ = [
     'TriviaStats', 'TriviaAchievement', 'CustomQuestion', 'GuildLeaderboard',
-    'AngleGame', 'AngleStats',
+    'AngleGame', 'AngleStats', 'AngleAchievement',
+    'RPSStats', 'RPSAchievement',
 ]

--- a/plugins/games/models/angle.py
+++ b/plugins/games/models/angle.py
@@ -87,3 +87,26 @@ class AngleStats(Base):
 
     def __repr__(self) -> str:
         return f"<AngleStats(user={self.user_id}, guild={self.guild_id}, wins={self.wins}/{self.total_games})>"
+
+
+class AngleAchievement(Base):
+    """An unlocked angle-game achievement for a user in a guild."""
+
+    __tablename__ = "angle_achievements"
+    __table_args__ = (
+        UniqueConstraint("user_id", "guild_id", "achievement_id", name="uq_angle_achievement_user_guild_id"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
+    guild_id: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
+    achievement_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    emoji: Mapped[str] = mapped_column(String(16), nullable=False)
+    unlocked_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC)
+    )
+
+    def __repr__(self) -> str:
+        return f"<AngleAchievement(user={self.user_id}, id={self.achievement_id})>"

--- a/plugins/games/models/rps.py
+++ b/plugins/games/models/rps.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import BigInteger, DateTime, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from bot.database.models import Base
+
+
+class RPSStats(Base):
+    """Persistent Rock-Paper-Scissors statistics per user per guild."""
+
+    __tablename__ = "rps_stats"
+    __table_args__ = (
+        UniqueConstraint("user_id", "guild_id", name="uq_rps_stats_user_guild"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
+    guild_id: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
+
+    total_games: Mapped[int] = mapped_column(Integer, default=0)
+    wins: Mapped[int] = mapped_column(Integer, default=0)
+    losses: Mapped[int] = mapped_column(Integer, default=0)
+    draws: Mapped[int] = mapped_column(Integer, default=0)
+
+    # Wins broken down by the choice the player used
+    rock_wins: Mapped[int] = mapped_column(Integer, default=0)
+    paper_wins: Mapped[int] = mapped_column(Integer, default=0)
+    scissors_wins: Mapped[int] = mapped_column(Integer, default=0)
+
+    current_win_streak: Mapped[int] = mapped_column(Integer, default=0)
+    best_win_streak: Mapped[int] = mapped_column(Integer, default=0)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC)
+    )
+
+    @property
+    def win_rate(self) -> float:
+        if self.total_games == 0:
+            return 0.0
+        return (self.wins / self.total_games) * 100
+
+    def __repr__(self) -> str:
+        return f"<RPSStats(user={self.user_id}, guild={self.guild_id}, wins={self.wins}/{self.total_games})>"
+
+
+class RPSAchievement(Base):
+    """An unlocked RPS achievement for a user in a guild."""
+
+    __tablename__ = "rps_achievements"
+    __table_args__ = (
+        UniqueConstraint("user_id", "guild_id", "achievement_id", name="uq_rps_achievement_user_guild_id"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
+    guild_id: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
+    achievement_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    emoji: Mapped[str] = mapped_column(String(16), nullable=False)
+    unlocked_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC)
+    )
+
+    def __repr__(self) -> str:
+        return f"<RPSAchievement(user={self.user_id}, id={self.achievement_id})>"

--- a/plugins/games/plugin.py
+++ b/plugins/games/plugin.py
@@ -9,9 +9,11 @@ from typing import TYPE_CHECKING, Any
 
 import aiohttp
 import hikari
+from fastapi import FastAPI
 
 from bot.plugins.base import BasePlugin
 from bot.plugins.mixins import DatabaseMixin
+from bot.web.mixins import WebPanelMixin
 
 from .commands.trivia import setup_trivia_commands
 from .config import ANGLE_MAX_ATTEMPTS, ANGLE_POINTS, EMBED_COLORS, games_settings
@@ -22,7 +24,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class GamesPlugin(DatabaseMixin, BasePlugin):
+class GamesPlugin(DatabaseMixin, WebPanelMixin, BasePlugin):
     """Interactive games plugin with trivia, angle game, RPS, scoring, and achievements."""
 
     def __init__(self, bot: DiscordBot) -> None:
@@ -32,9 +34,17 @@ class GamesPlugin(DatabaseMixin, BasePlugin):
         self._replay_games: dict[tuple[int, int], dict[str, Any]] = {}
 
         # Register database models
-        from .models import CustomQuestion, GuildLeaderboard, TriviaAchievement, TriviaStats
-        from .models.angle import AngleGame, AngleStats
-        self.register_models(TriviaStats, TriviaAchievement, CustomQuestion, GuildLeaderboard, AngleGame, AngleStats)
+        from .models import (
+            AngleAchievement, AngleGame, AngleStats,
+            CustomQuestion, GuildLeaderboard,
+            RPSAchievement, RPSStats,
+            TriviaAchievement, TriviaStats,
+        )
+        self.register_models(
+            TriviaStats, TriviaAchievement, CustomQuestion, GuildLeaderboard,
+            AngleGame, AngleStats, AngleAchievement,
+            RPSStats, RPSAchievement,
+        )
 
         # Register commands
         self._register_commands()
@@ -494,6 +504,8 @@ class GamesPlugin(DatabaseMixin, BasePlugin):
                     stats.current_win_streak = 0
 
                 await session.commit()
+                if game.is_complete:
+                    await self._check_angle_achievements(user_id, guild_id, stats, session)
 
             await session.refresh(game)
             return self._angle_game_to_dict(game)
@@ -525,3 +537,250 @@ class GamesPlugin(DatabaseMixin, BasePlugin):
                 )
             )
             return result.scalars().first()
+
+    async def get_angle_achievements(self, user_id: int, guild_id: int) -> list[Any]:
+        """Return all unlocked AngleAchievements for a user in a guild."""
+        from .models.angle import AngleAchievement
+
+        async with self.db_session() as session:
+            from sqlalchemy import select
+            result = await session.execute(
+                select(AngleAchievement).where(
+                    AngleAchievement.user_id == user_id,
+                    AngleAchievement.guild_id == guild_id,
+                ).order_by(AngleAchievement.unlocked_at)
+            )
+            return list(result.scalars().all())
+
+    async def _check_angle_achievements(
+        self, user_id: int, guild_id: int, stats: Any, session: Any, channel_id: int | None = None
+    ) -> None:
+        """Award any new angle achievements earned based on current stats."""
+        from sqlalchemy import select
+
+        from .config import ANGLE_ACHIEVEMENTS
+        from .models.angle import AngleAchievement
+
+        result = await session.execute(
+            select(AngleAchievement).where(
+                AngleAchievement.user_id == user_id,
+                AngleAchievement.guild_id == guild_id,
+            )
+        )
+        existing = {ach.achievement_id for ach in result.scalars().all()}
+
+        for achievement_id, data in ANGLE_ACHIEVEMENTS.items():
+            if achievement_id in existing:
+                continue
+
+            req = data["requirement"]
+            req_type, req_value = req["type"], req["value"]
+
+            earned = False
+            if req_type == "wins" and stats.wins >= req_value:
+                earned = True
+            elif req_type == "exact_wins" and stats.exact_wins >= req_value:
+                earned = True
+            elif req_type == "close_wins" and stats.close_wins >= req_value:
+                earned = True
+            elif req_type == "total_games" and stats.total_games >= req_value:
+                earned = True
+            elif req_type == "win_streak" and stats.best_win_streak >= req_value:
+                earned = True
+            elif req_type == "total_points" and stats.total_points >= req_value:
+                earned = True
+
+            if earned:
+                achievement = AngleAchievement(
+                    user_id=user_id,
+                    guild_id=guild_id,
+                    achievement_id=achievement_id,
+                    name=data["name"],
+                    description=data["description"],
+                    emoji=data["emoji"],
+                )
+                session.add(achievement)
+                await session.commit()
+                logger.info("Awarded angle achievement '%s' to user %s", achievement_id, user_id)
+
+                if channel_id:
+                    try:
+                        embed = hikari.Embed(
+                            title=f"{data['emoji']} Achievement Unlocked!",
+                            description=(
+                                f"<@{user_id}> earned **{data['name']}**\n{data['description']}"
+                            ),
+                            color=hikari.Color(EMBED_COLORS["achievement"]),
+                        )
+                        await self.bot.rest.create_message(channel_id, embed=embed)
+                    except Exception as exc:
+                        logger.warning("Failed to send angle achievement notification: %s", exc)
+
+    # -------------------------------------------------------------------------
+    # RPS helpers
+    # -------------------------------------------------------------------------
+
+    async def record_rps_result(
+        self,
+        user_id: int,
+        guild_id: int,
+        player_choice: str,
+        result: str,
+        channel_id: int | None = None,
+    ) -> None:
+        """Update RPSStats and check for new achievements after a game."""
+        from .models.rps import RPSAchievement, RPSStats
+
+        async with self.db_session() as session:
+            from sqlalchemy import select
+
+            res = await session.execute(
+                select(RPSStats).where(
+                    RPSStats.user_id == user_id,
+                    RPSStats.guild_id == guild_id,
+                )
+            )
+            stats = res.scalars().first()
+            if not stats:
+                stats = RPSStats(
+                    user_id=user_id,
+                    guild_id=guild_id,
+                    total_games=0, wins=0, losses=0, draws=0,
+                    rock_wins=0, paper_wins=0, scissors_wins=0,
+                    current_win_streak=0, best_win_streak=0,
+                )
+                session.add(stats)
+
+            stats.total_games += 1
+            if result == "win":
+                stats.wins += 1
+                stats.current_win_streak += 1
+                if stats.current_win_streak > stats.best_win_streak:
+                    stats.best_win_streak = stats.current_win_streak
+                if player_choice == "rock":
+                    stats.rock_wins += 1
+                elif player_choice == "paper":
+                    stats.paper_wins += 1
+                elif player_choice == "scissors":
+                    stats.scissors_wins += 1
+            elif result == "lose":
+                stats.losses += 1
+                stats.current_win_streak = 0
+            else:  # draw
+                stats.draws += 1
+                stats.current_win_streak = 0
+
+            await session.commit()
+            await self._check_rps_achievements(user_id, guild_id, stats, session, channel_id=channel_id)
+
+    async def _check_rps_achievements(
+        self, user_id: int, guild_id: int, stats: Any, session: Any, channel_id: int | None = None
+    ) -> None:
+        """Award any new RPS achievements earned based on current stats."""
+        from sqlalchemy import select
+
+        from .config import RPS_ACHIEVEMENTS
+        from .models.rps import RPSAchievement
+
+        result = await session.execute(
+            select(RPSAchievement).where(
+                RPSAchievement.user_id == user_id,
+                RPSAchievement.guild_id == guild_id,
+            )
+        )
+        existing = {ach.achievement_id for ach in result.scalars().all()}
+
+        for achievement_id, data in RPS_ACHIEVEMENTS.items():
+            if achievement_id in existing:
+                continue
+
+            req = data["requirement"]
+            req_type, req_value = req["type"], req["value"]
+
+            earned = False
+            if req_type == "wins" and stats.wins >= req_value:
+                earned = True
+            elif req_type == "total_games" and stats.total_games >= req_value:
+                earned = True
+            elif req_type == "win_streak" and stats.best_win_streak >= req_value:
+                earned = True
+            elif req_type == "rock_wins" and stats.rock_wins >= req_value:
+                earned = True
+            elif req_type == "paper_wins" and stats.paper_wins >= req_value:
+                earned = True
+            elif req_type == "scissors_wins" and stats.scissors_wins >= req_value:
+                earned = True
+            elif req_type == "draws" and stats.draws >= req_value:
+                earned = True
+
+            if earned:
+                achievement = RPSAchievement(
+                    user_id=user_id,
+                    guild_id=guild_id,
+                    achievement_id=achievement_id,
+                    name=data["name"],
+                    description=data["description"],
+                    emoji=data["emoji"],
+                )
+                session.add(achievement)
+                await session.commit()
+                logger.info("Awarded RPS achievement '%s' to user %s", achievement_id, user_id)
+
+                if channel_id:
+                    try:
+                        embed = hikari.Embed(
+                            title=f"{data['emoji']} Achievement Unlocked!",
+                            description=(
+                                f"<@{user_id}> earned **{data['name']}**\n{data['description']}"
+                            ),
+                            color=hikari.Color(EMBED_COLORS["achievement"]),
+                        )
+                        await self.bot.rest.create_message(channel_id, embed=embed)
+                    except Exception as exc:
+                        logger.warning("Failed to send RPS achievement notification: %s", exc)
+
+    async def get_rps_stats(self, user_id: int, guild_id: int) -> Any:
+        """Return RPSStats for a user in a guild, or None."""
+        from .models.rps import RPSStats
+
+        async with self.db_session() as session:
+            from sqlalchemy import select
+            result = await session.execute(
+                select(RPSStats).where(
+                    RPSStats.user_id == user_id,
+                    RPSStats.guild_id == guild_id,
+                )
+            )
+            return result.scalars().first()
+
+    async def get_rps_achievements(self, user_id: int, guild_id: int) -> list[Any]:
+        """Return all unlocked RPSAchievements for a user in a guild."""
+        from .models.rps import RPSAchievement
+
+        async with self.db_session() as session:
+            from sqlalchemy import select
+            result = await session.execute(
+                select(RPSAchievement).where(
+                    RPSAchievement.user_id == user_id,
+                    RPSAchievement.guild_id == guild_id,
+                ).order_by(RPSAchievement.unlocked_at)
+            )
+            return list(result.scalars().all())
+
+    # -------------------------------------------------------------------------
+    # Web panel
+    # -------------------------------------------------------------------------
+
+    def get_panel_info(self) -> dict[str, Any]:
+        """Return metadata for this plugin's web panel."""
+        return {
+            "name": "Games",
+            "description": "View achievements for Trivia, Angle, and RPS games",
+            "route": "/plugin/games",
+            "icon": "fa-solid fa-trophy",
+            "nav_order": 20,
+        }
+
+    def register_web_routes(self, app: FastAPI) -> None:
+        from .web import register_games_routes
+        register_games_routes(app, self)

--- a/plugins/games/templates/panel.html
+++ b/plugins/games/templates/panel.html
@@ -1,0 +1,292 @@
+{% extends "plugin_base.html" %}
+
+{% block title %}Games Achievements — {{ bot_name }}{% endblock %}
+
+{% block extra_styles %}
+/* ── Achievement panel styles ── */
+.ach-lookup-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--card-radius);
+  padding: 1.6rem 1.8rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.ach-lookup-card h2 {
+  margin: 0 0 1.2rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ach-form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto auto;
+  gap: 0.85rem;
+  align-items: end;
+}
+
+@media (max-width: 768px) {
+  .ach-form-row {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 540px) {
+  .ach-form-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Results area */
+#ach-results {
+  min-height: 6rem;
+}
+
+.ach-placeholder, .ach-error {
+  color: var(--text-secondary);
+  text-align: center;
+  padding: 2.5rem 1rem;
+  font-size: 1rem;
+}
+
+.ach-error {
+  color: var(--danger-color);
+}
+
+/* Overall progress summary */
+.ach-summary {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--card-radius);
+  padding: 1.25rem 1.6rem;
+  box-shadow: var(--shadow-sm);
+  margin-bottom: 0.25rem;
+}
+
+.ach-summary-bar-wrap {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.65rem;
+}
+
+.ach-summary-label {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.ach-summary-count {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--accent-color);
+}
+
+/* Progress bars */
+.ach-progress-bar-bg {
+  background: rgba(148, 163, 184, 0.22);
+  border-radius: 999px;
+  height: 10px;
+  overflow: hidden;
+}
+
+.ach-progress-bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent-color), var(--accent-hover));
+  transition: width 0.5s ease;
+}
+
+.ach-progress-bar-sm {
+  height: 6px;
+  margin-top: 0.35rem;
+}
+
+.ach-progress-bar-locked {
+  background: linear-gradient(90deg, #64748b, #94a3b8);
+}
+
+/* Sections */
+.ach-section {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--card-radius);
+  padding: 1.4rem 1.6rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.ach-section-title {
+  margin: 0 0 1.2rem;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.ach-section-count {
+  margin-left: auto;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: rgba(148, 163, 184, 0.2);
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+}
+
+/* Achievement grid */
+.ach-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 0.9rem;
+}
+
+/* Achievement card */
+.ach-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.9rem;
+  padding: 1rem 1.1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.ach-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.ach-unlocked {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.1), rgba(5, 150, 105, 0.06));
+  border-color: rgba(16, 185, 129, 0.35);
+}
+
+.ach-locked {
+  background: rgba(148, 163, 184, 0.07);
+  border-color: rgba(148, 163, 184, 0.18);
+}
+
+.ach-emoji {
+  font-size: 1.9rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.ach-emoji-locked {
+  filter: grayscale(1);
+  opacity: 0.45;
+}
+
+.ach-body {
+  min-width: 0;
+  flex: 1;
+}
+
+.ach-name {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  margin-bottom: 0.2rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ach-locked .ach-name {
+  color: var(--text-secondary);
+}
+
+.ach-desc {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+  margin-bottom: 0.45rem;
+}
+
+.ach-badge-unlocked {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #059669;
+  background: rgba(16, 185, 129, 0.18);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  border-radius: 999px;
+  padding: 0.15rem 0.55rem;
+}
+
+.ach-progress-wrap {
+  margin-top: 0.2rem;
+}
+
+.ach-progress-label {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+/* Dark mode tweaks */
+[data-theme="dark"] .ach-lookup-card,
+[data-theme="dark"] .ach-summary,
+[data-theme="dark"] .ach-section {
+  background: rgba(15, 23, 42, 0.92);
+}
+
+[data-theme="dark"] .ach-unlocked {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.13), rgba(5, 150, 105, 0.08));
+  border-color: rgba(52, 211, 153, 0.3);
+}
+
+[data-theme="dark"] .ach-badge-unlocked {
+  color: #34d399;
+  background: rgba(52, 211, 153, 0.15);
+  border-color: rgba(52, 211, 153, 0.3);
+}
+{% endblock %}
+
+{% block content %}
+<!-- Lookup form -->
+<div class="ach-lookup-card">
+  <h2><i class="fa-solid fa-magnifying-glass"></i> Look up achievements</h2>
+  <div class="ach-form-row">
+    <div class="input-group">
+      <label for="ach-user-id">User ID</label>
+      <input id="ach-user-id" name="user_id" type="text" placeholder="e.g. 123456789012345678">
+    </div>
+    <div class="input-group">
+      <label for="ach-guild-id">Guild ID</label>
+      <input id="ach-guild-id" name="guild_id" type="text" placeholder="e.g. 987654321098765432">
+    </div>
+    <div class="input-group">
+      <label for="ach-filter">Game</label>
+      <select id="ach-filter" name="game_filter">
+        <option value="all">All games</option>
+        <option value="trivia">Trivia</option>
+        <option value="angle">Angle</option>
+        <option value="rps">Rock Paper Scissors</option>
+      </select>
+    </div>
+    <button
+      class="btn"
+      hx-get="/plugin/games/api/achievements"
+      hx-target="#ach-results"
+      hx-swap="innerHTML"
+      hx-include="#ach-user-id, #ach-guild-id, #ach-filter"
+      hx-indicator="#ach-spinner"
+    >
+      <i class="fa-solid fa-search"></i> Load
+      <span id="ach-spinner" class="htmx-indicator">…</span>
+    </button>
+  </div>
+</div>
+
+<!-- Results -->
+<div id="ach-results">
+  <p class="ach-placeholder">Enter a User ID and Guild ID above, then click Load.</p>
+</div>
+{% endblock %}

--- a/plugins/games/views/rps.py
+++ b/plugins/games/views/rps.py
@@ -34,10 +34,11 @@ def _determine_result(player: str, bot_choice: str) -> str:
 class RPSView(miru.View):
     """Show three buttons (Rock / Paper / Scissors); resolve immediately on click."""
 
-    def __init__(self, plugin: GamesPlugin, invoker_id: int) -> None:
+    def __init__(self, plugin: GamesPlugin, invoker_id: int, guild_id: int = 0) -> None:
         super().__init__(timeout=60)
         self.plugin = plugin
         self.invoker_id = invoker_id
+        self.guild_id = guild_id
 
     async def _handle_choice(self, ctx: miru.ViewContext, player_choice: str) -> None:
         if ctx.user.id != self.invoker_id:
@@ -86,6 +87,16 @@ class RPSView(miru.View):
             await self.message.edit(embed=embed, components=self)
         except Exception as exc:
             logger.error("Failed to edit RPS message: %s", exc)
+
+        # Persist stats and check achievements (fire-and-forget)
+        if self.guild_id:
+            try:
+                channel_id = int(ctx.channel_id) if ctx.channel_id else None
+                await self.plugin.record_rps_result(
+                    int(ctx.user.id), self.guild_id, player_choice, result, channel_id=channel_id
+                )
+            except Exception as exc:
+                logger.warning("Failed to record RPS result: %s", exc)
 
         await ctx.respond(flags=hikari.MessageFlag.EPHEMERAL, content="\u200b")
         self.stop()

--- a/plugins/games/web/__init__.py
+++ b/plugins/games/web/__init__.py
@@ -1,0 +1,3 @@
+from .routes import register_games_routes
+
+__all__ = ["register_games_routes"]

--- a/plugins/games/web/routes.py
+++ b/plugins/games/web/routes.py
@@ -1,0 +1,260 @@
+"""FastAPI routes for the games plugin web panel."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+
+from ..config import ANGLE_ACHIEVEMENTS, RPS_ACHIEVEMENTS, TRIVIA_ACHIEVEMENTS
+
+if TYPE_CHECKING:
+    from ..plugin import GamesPlugin
+
+
+def register_games_routes(app: FastAPI, plugin: "GamesPlugin") -> None:
+    """Register FastAPI routes for the games plugin web panel."""
+
+    @app.get("/plugin/games", response_class=HTMLResponse)
+    async def games_panel(request: Request) -> HTMLResponse:
+        return plugin.render_plugin_template(request, "panel.html")
+
+    @app.get("/plugin/games/api/achievements", response_class=HTMLResponse)
+    async def api_achievements(
+        request: Request,
+        user_id: str = "",
+        guild_id: str = "",
+        game_filter: str = "all",
+    ) -> HTMLResponse:
+        """Return an HTMX fragment showing all achievements with attained/progress info."""
+        if not user_id or not guild_id:
+            return HTMLResponse(
+                '<p class="ach-placeholder">Enter a User ID and Guild ID above, then click Load.</p>'
+            )
+
+        try:
+            uid = int(user_id)
+            gid = int(guild_id)
+        except ValueError:
+            return HTMLResponse('<p class="ach-error">Invalid User ID or Guild ID — must be integers.</p>')
+
+        # --- Fetch stats + unlocked achievements ---
+        trivia_stats = await plugin.get_trivia_stats(uid, gid)
+        angle_stats = await plugin.get_angle_stats(uid, gid)
+        rps_stats = await plugin.get_rps_stats(uid, gid)
+
+        trivia_unlocked = {a.achievement_id for a in await plugin.get_trivia_achievements(uid, gid)}
+        angle_unlocked = {a.achievement_id for a in await plugin.get_angle_achievements(uid, gid)}
+        rps_unlocked = {a.achievement_id for a in await plugin.get_rps_achievements(uid, gid)}
+
+        # --- Build section data ---
+        sections: list[dict] = []
+
+        if game_filter in ("all", "trivia"):
+            sections.append({
+                "title": "Trivia",
+                "icon": "fa-solid fa-brain",
+                "color": "#9932CC",
+                "achievements": _build_trivia_items(TRIVIA_ACHIEVEMENTS, trivia_unlocked, trivia_stats),
+            })
+
+        if game_filter in ("all", "angle"):
+            sections.append({
+                "title": "Angle",
+                "icon": "fa-solid fa-drafting-compass",
+                "color": "#E67E22",
+                "achievements": _build_angle_items(ANGLE_ACHIEVEMENTS, angle_unlocked, angle_stats),
+            })
+
+        if game_filter in ("all", "rps"):
+            sections.append({
+                "title": "Rock Paper Scissors",
+                "icon": "fa-solid fa-hand-back-fist",
+                "color": "#1ABC9C",
+                "achievements": _build_rps_items(RPS_ACHIEVEMENTS, rps_unlocked, rps_stats),
+            })
+
+        total_unlocked = len(trivia_unlocked) + len(angle_unlocked) + len(rps_unlocked)
+        total_all = len(TRIVIA_ACHIEVEMENTS) + len(ANGLE_ACHIEVEMENTS) + len(RPS_ACHIEVEMENTS)
+
+        return HTMLResponse(_render_achievements(sections, total_unlocked, total_all))
+
+
+# ---------------------------------------------------------------------------
+# Progress helpers
+# ---------------------------------------------------------------------------
+
+def _pct(current: int, goal: int) -> int:
+    return min(100, int(current / max(goal, 1) * 100))
+
+
+def _build_trivia_items(definitions: dict, unlocked: set, stats: object | None) -> list[dict]:
+    items = []
+    for ach_id, data in definitions.items():
+        req = data["requirement"]
+        req_type, req_value = req["type"], req["value"]
+
+        current = 0
+        if stats:
+            if req_type == "correct_answers":
+                current = stats.correct_answers
+            elif req_type == "streak":
+                current = stats.best_streak
+            elif req_type == "fast_answers":
+                current = stats.fast_answers
+            elif req_type == "hard_correct":
+                current = stats.hard_correct
+            elif req_type == "total_points":
+                current = stats.total_points
+            elif req_type == "perfect_accuracy":
+                current = 20 if stats.recent_perfect else 0
+
+        label = req_type.replace("_", " ").title()
+        items.append({
+            "id": ach_id,
+            "name": data["name"],
+            "description": data["description"],
+            "emoji": data["emoji"],
+            "unlocked": ach_id in unlocked,
+            "current": current,
+            "goal": req_value,
+            "pct": _pct(current, req_value),
+            "progress_label": f"{label}: {current:,} / {req_value:,}",
+        })
+    return items
+
+
+def _build_angle_items(definitions: dict, unlocked: set, stats: object | None) -> list[dict]:
+    items = []
+    for ach_id, data in definitions.items():
+        req = data["requirement"]
+        req_type, req_value = req["type"], req["value"]
+
+        current = 0
+        if stats:
+            if req_type == "wins":
+                current = stats.wins
+            elif req_type == "exact_wins":
+                current = stats.exact_wins
+            elif req_type == "close_wins":
+                current = stats.close_wins
+            elif req_type == "total_games":
+                current = stats.total_games
+            elif req_type == "win_streak":
+                current = stats.best_win_streak
+            elif req_type == "total_points":
+                current = stats.total_points
+
+        label = req_type.replace("_", " ").title()
+        items.append({
+            "id": ach_id,
+            "name": data["name"],
+            "description": data["description"],
+            "emoji": data["emoji"],
+            "unlocked": ach_id in unlocked,
+            "current": current,
+            "goal": req_value,
+            "pct": _pct(current, req_value),
+            "progress_label": f"{label}: {current:,} / {req_value:,}",
+        })
+    return items
+
+
+def _build_rps_items(definitions: dict, unlocked: set, stats: object | None) -> list[dict]:
+    items = []
+    for ach_id, data in definitions.items():
+        req = data["requirement"]
+        req_type, req_value = req["type"], req["value"]
+
+        current = 0
+        if stats:
+            if req_type == "wins":
+                current = stats.wins
+            elif req_type == "total_games":
+                current = stats.total_games
+            elif req_type == "win_streak":
+                current = stats.best_win_streak
+            elif req_type == "rock_wins":
+                current = stats.rock_wins
+            elif req_type == "paper_wins":
+                current = stats.paper_wins
+            elif req_type == "scissors_wins":
+                current = stats.scissors_wins
+            elif req_type == "draws":
+                current = stats.draws
+
+        label = req_type.replace("_", " ").title()
+        items.append({
+            "id": ach_id,
+            "name": data["name"],
+            "description": data["description"],
+            "emoji": data["emoji"],
+            "unlocked": ach_id in unlocked,
+            "current": current,
+            "goal": req_value,
+            "pct": _pct(current, req_value),
+            "progress_label": f"{label}: {current:,} / {req_value:,}",
+        })
+    return items
+
+
+# ---------------------------------------------------------------------------
+# HTML rendering
+# ---------------------------------------------------------------------------
+
+def _render_achievements(sections: list[dict], total_unlocked: int, total_all: int) -> str:
+    overall_pct = _pct(total_unlocked, total_all)
+    html = f"""
+<div class="ach-summary">
+  <div class="ach-summary-bar-wrap">
+    <span class="ach-summary-label">Overall progress</span>
+    <span class="ach-summary-count">{total_unlocked} / {total_all}</span>
+  </div>
+  <div class="ach-progress-bar-bg">
+    <div class="ach-progress-bar-fill" style="width:{overall_pct}%"></div>
+  </div>
+</div>
+"""
+    for section in sections:
+        unlocked_count = sum(1 for a in section["achievements"] if a["unlocked"])
+        section_total = len(section["achievements"])
+        html += f"""
+<div class="ach-section">
+  <h3 class="ach-section-title">
+    <i class="{section['icon']}" style="color:{section['color']}"></i>
+    {section['title']}
+    <span class="ach-section-count">{unlocked_count}/{section_total}</span>
+  </h3>
+  <div class="ach-grid">
+"""
+        for ach in section["achievements"]:
+            if ach["unlocked"]:
+                html += f"""
+    <div class="ach-card ach-unlocked">
+      <div class="ach-emoji">{ach['emoji']}</div>
+      <div class="ach-body">
+        <div class="ach-name">{ach['name']}</div>
+        <div class="ach-desc">{ach['description']}</div>
+        <div class="ach-badge-unlocked">Unlocked</div>
+      </div>
+    </div>
+"""
+            else:
+                html += f"""
+    <div class="ach-card ach-locked">
+      <div class="ach-emoji ach-emoji-locked">{ach['emoji']}</div>
+      <div class="ach-body">
+        <div class="ach-name">{ach['name']}</div>
+        <div class="ach-desc">{ach['description']}</div>
+        <div class="ach-progress-wrap">
+          <div class="ach-progress-label">{ach['progress_label']}</div>
+          <div class="ach-progress-bar-bg ach-progress-bar-sm">
+            <div class="ach-progress-bar-fill ach-progress-bar-locked" style="width:{ach['pct']}%"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+"""
+        html += "  </div>\n</div>\n"
+
+    return html


### PR DESCRIPTION
Achievements:
- 7 Angle achievements (Bullseye, Sharpshooter, Precision Master, Veteran, On a Roll, Point Collector, Close Enough) tracked via new AngleAchievement model and _check_angle_achievements() called on each points-eligible game end
- 8 RPS achievements (First Blood, Veteran, Champion, Unstoppable, Rock Solid, Paper Trail, Scissor Happy, Draw Master) tracked via new RPSStats + RPSAchievement models; RPSView now records results and checks achievements after every game

Models:
- AngleAchievement added to models/angle.py
- models/rps.py: new RPSStats (total_games, wins, losses, draws, per-choice wins, streak) and RPSAchievement

Web panel (/plugin/games):
- GamesPlugin now inherits WebPanelMixin and registers routes
- GET /plugin/games/api/achievements?user_id=&guild_id=&game_filter= returns an HTMX fragment with unlocked (green, 'Unlocked' badge) and unattained (greyed, progress bar + current/goal label) achievements for all three games
- Filter by All / Trivia / Angle / RPS via dropdown
- Overall progress bar at the top of results

https://claude.ai/code/session_015FY8CBbSeb6kHuyJJ5MMfR