### PR TITLE
Simplify achievements panel: use sidebar guild + session user

### DIFF
--- a/plugins/games/templates/panel.html
+++ b/plugins/games/templates/panel.html
@@ -4,58 +4,53 @@
 
 {% block extra_styles %}
 /* ── Achievement panel styles ── */
-.ach-lookup-card {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--card-radius);
-  padding: 1.6rem 1.8rem;
-  box-shadow: var(--shadow-sm);
-}
-
-.ach-lookup-card h2 {
-  margin: 0 0 1.2rem;
-  font-size: 1.25rem;
-  font-weight: 700;
-  color: var(--text-primary);
+.ach-toolbar {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 1rem;
+  flex-wrap: wrap;
 }
 
-.ach-form-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr auto auto;
-  gap: 0.85rem;
-  align-items: end;
+.ach-toolbar label {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  white-space: nowrap;
 }
 
-@media (max-width: 768px) {
-  .ach-form-row {
-    grid-template-columns: 1fr 1fr;
-  }
+.ach-toolbar select {
+  padding: 0.6rem 0.85rem;
+  border: 1px solid var(--input-border);
+  border-radius: 10px;
+  font-size: 0.95rem;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  box-shadow: 0 10px 25px rgba(15,23,42,0.08);
+  transition: border 0.2s, box-shadow 0.2s;
+  cursor: pointer;
 }
 
-@media (max-width: 540px) {
-  .ach-form-row {
-    grid-template-columns: 1fr;
-  }
+.ach-toolbar select:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 /* Results area */
 #ach-results {
-  min-height: 6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
-.ach-placeholder, .ach-error {
+.ach-msg {
   color: var(--text-secondary);
   text-align: center;
   padding: 2.5rem 1rem;
   font-size: 1rem;
 }
 
-.ach-error {
-  color: var(--danger-color);
-}
+.ach-error { color: var(--danger-color); }
 
 /* Overall progress summary */
 .ach-summary {
@@ -64,7 +59,6 @@
   border-radius: var(--card-radius);
   padding: 1.25rem 1.6rem;
   box-shadow: var(--shadow-sm);
-  margin-bottom: 0.25rem;
 }
 
 .ach-summary-bar-wrap {
@@ -100,14 +94,8 @@
   transition: width 0.5s ease;
 }
 
-.ach-progress-bar-sm {
-  height: 6px;
-  margin-top: 0.35rem;
-}
-
-.ach-progress-bar-locked {
-  background: linear-gradient(90deg, #64748b, #94a3b8);
-}
+.ach-progress-bar-sm { height: 6px; margin-top: 0.35rem; }
+.ach-progress-bar-locked { background: linear-gradient(90deg, #64748b, #94a3b8); }
 
 /* Sections */
 .ach-section {
@@ -141,7 +129,7 @@
 /* Achievement grid */
 .ach-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(255px, 1fr));
   gap: 0.9rem;
 }
 
@@ -153,16 +141,13 @@
   padding: 1rem 1.1rem;
   border-radius: 12px;
   border: 1px solid var(--border-color);
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition: transform 0.15s, box-shadow 0.15s;
 }
 
-.ach-card:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-md);
-}
+.ach-card:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); }
 
 .ach-unlocked {
-  background: linear-gradient(135deg, rgba(16, 185, 129, 0.1), rgba(5, 150, 105, 0.06));
+  background: linear-gradient(135deg, rgba(16,185,129,0.1), rgba(5,150,105,0.06));
   border-color: rgba(16, 185, 129, 0.35);
 }
 
@@ -171,21 +156,10 @@
   border-color: rgba(148, 163, 184, 0.18);
 }
 
-.ach-emoji {
-  font-size: 1.9rem;
-  line-height: 1;
-  flex-shrink: 0;
-}
+.ach-emoji { font-size: 1.9rem; line-height: 1; flex-shrink: 0; }
+.ach-emoji-locked { filter: grayscale(1); opacity: 0.4; }
 
-.ach-emoji-locked {
-  filter: grayscale(1);
-  opacity: 0.45;
-}
-
-.ach-body {
-  min-width: 0;
-  flex: 1;
-}
+.ach-body { min-width: 0; flex: 1; }
 
 .ach-name {
   font-weight: 700;
@@ -197,9 +171,7 @@
   text-overflow: ellipsis;
 }
 
-.ach-locked .ach-name {
-  color: var(--text-secondary);
-}
+.ach-locked .ach-name { color: var(--text-secondary); }
 
 .ach-desc {
   font-size: 0.82rem;
@@ -215,78 +187,60 @@
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: #059669;
-  background: rgba(16, 185, 129, 0.18);
-  border: 1px solid rgba(16, 185, 129, 0.3);
+  background: rgba(16,185,129,0.18);
+  border: 1px solid rgba(16,185,129,0.3);
   border-radius: 999px;
   padding: 0.15rem 0.55rem;
 }
 
-.ach-progress-wrap {
-  margin-top: 0.2rem;
-}
-
-.ach-progress-label {
-  font-size: 0.78rem;
-  color: var(--text-secondary);
-}
+.ach-progress-wrap { margin-top: 0.2rem; }
+.ach-progress-label { font-size: 0.78rem; color: var(--text-secondary); }
 
 /* Dark mode tweaks */
-[data-theme="dark"] .ach-lookup-card,
 [data-theme="dark"] .ach-summary,
-[data-theme="dark"] .ach-section {
-  background: rgba(15, 23, 42, 0.92);
-}
+[data-theme="dark"] .ach-section { background: rgba(15,23,42,0.92); }
 
 [data-theme="dark"] .ach-unlocked {
-  background: linear-gradient(135deg, rgba(16, 185, 129, 0.13), rgba(5, 150, 105, 0.08));
-  border-color: rgba(52, 211, 153, 0.3);
+  background: linear-gradient(135deg, rgba(16,185,129,0.13), rgba(5,150,105,0.08));
+  border-color: rgba(52,211,153,0.3);
 }
 
 [data-theme="dark"] .ach-badge-unlocked {
   color: #34d399;
-  background: rgba(52, 211, 153, 0.15);
-  border-color: rgba(52, 211, 153, 0.3);
+  background: rgba(52,211,153,0.15);
+  border-color: rgba(52,211,153,0.3);
 }
 {% endblock %}
 
 {% block content %}
-<!-- Lookup form -->
-<div class="ach-lookup-card">
-  <h2><i class="fa-solid fa-magnifying-glass"></i> Look up achievements</h2>
-  <div class="ach-form-row">
-    <div class="input-group">
-      <label for="ach-user-id">User ID</label>
-      <input id="ach-user-id" name="user_id" type="text" placeholder="e.g. 123456789012345678">
-    </div>
-    <div class="input-group">
-      <label for="ach-guild-id">Guild ID</label>
-      <input id="ach-guild-id" name="guild_id" type="text" placeholder="e.g. 987654321098765432">
-    </div>
-    <div class="input-group">
-      <label for="ach-filter">Game</label>
-      <select id="ach-filter" name="game_filter">
-        <option value="all">All games</option>
-        <option value="trivia">Trivia</option>
-        <option value="angle">Angle</option>
-        <option value="rps">Rock Paper Scissors</option>
-      </select>
-    </div>
-    <button
-      class="btn"
+<!-- Toolbar: game filter only -->
+<div class="feature-card" style="padding:1.2rem 1.6rem;">
+  <div class="ach-toolbar">
+    <i class="fa-solid fa-trophy" style="color:var(--accent-color);font-size:1.15rem;"></i>
+    <label for="ach-filter">Show:</label>
+    <select id="ach-filter" name="game_filter"
       hx-get="/plugin/games/api/achievements"
+      hx-trigger="change, guild-changed from:body"
       hx-target="#ach-results"
       hx-swap="innerHTML"
-      hx-include="#ach-user-id, #ach-guild-id, #ach-filter"
-      hx-indicator="#ach-spinner"
+      hx-vals="js:{guild_id: localStorage.getItem('selectedGuildId') || ''}"
     >
-      <i class="fa-solid fa-search"></i> Load
-      <span id="ach-spinner" class="htmx-indicator">…</span>
-    </button>
+      <option value="all">All games</option>
+      <option value="trivia">Trivia</option>
+      <option value="angle">Angle</option>
+      <option value="rps">Rock Paper Scissors</option>
+    </select>
+    <span class="htmx-indicator" style="color:var(--text-secondary);font-style:italic;">Loading…</span>
   </div>
 </div>
 
-<!-- Results -->
-<div id="ach-results">
-  <p class="ach-placeholder">Enter a User ID and Guild ID above, then click Load.</p>
+<!-- Results (auto-loaded on page load and on guild/filter change) -->
+<div id="ach-results"
+  hx-get="/plugin/games/api/achievements"
+  hx-trigger="load"
+  hx-vals="js:{guild_id: localStorage.getItem('selectedGuildId') || '', game_filter: document.getElementById('ach-filter')?.value || 'all'}"
+  hx-swap="innerHTML"
+>
+  <p class="ach-msg">Loading…</p>
 </div>
 {% endblock %}

--- a/plugins/games/web/routes.py
+++ b/plugins/games/web/routes.py
@@ -1,7 +1,7 @@
 """FastAPI routes for the games plugin web panel."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
@@ -10,6 +10,12 @@ from ..config import ANGLE_ACHIEVEMENTS, RPS_ACHIEVEMENTS, TRIVIA_ACHIEVEMENTS
 
 if TYPE_CHECKING:
     from ..plugin import GamesPlugin
+
+
+def _get_auth(plugin: "GamesPlugin"):
+    """Return the DiscordAuth instance or None."""
+    web_app = getattr(getattr(plugin, "web_panel", None), "web_app", None)
+    return getattr(web_app, "auth", None)
 
 
 def register_games_routes(app: FastAPI, plugin: "GamesPlugin") -> None:
@@ -22,23 +28,34 @@ def register_games_routes(app: FastAPI, plugin: "GamesPlugin") -> None:
     @app.get("/plugin/games/api/achievements", response_class=HTMLResponse)
     async def api_achievements(
         request: Request,
-        user_id: str = "",
         guild_id: str = "",
         game_filter: str = "all",
     ) -> HTMLResponse:
-        """Return an HTMX fragment showing all achievements with attained/progress info."""
-        if not user_id or not guild_id:
+        """Return an HTMX fragment with achievements for the current user in the selected guild."""
+        # Require authentication to identify the user
+        auth = _get_auth(plugin)
+        if not auth or not auth.is_authenticated(request):
             return HTMLResponse(
-                '<p class="ach-placeholder">Enter a User ID and Guild ID above, then click Load.</p>'
+                '<p class="ach-msg ach-error">Please <a href="/auth/login">log in</a> to view your achievements.</p>'
+            )
+
+        current_user = auth.get_current_user(request)
+        try:
+            uid = int(current_user["id"])
+        except (KeyError, ValueError, TypeError):
+            return HTMLResponse('<p class="ach-msg ach-error">Could not determine your user ID.</p>')
+
+        if not guild_id:
+            return HTMLResponse(
+                '<p class="ach-msg">Select a server from the sidebar to view your achievements.</p>'
             )
 
         try:
-            uid = int(user_id)
             gid = int(guild_id)
         except ValueError:
-            return HTMLResponse('<p class="ach-error">Invalid User ID or Guild ID — must be integers.</p>')
+            return HTMLResponse('<p class="ach-msg ach-error">Invalid Guild ID.</p>')
 
-        # --- Fetch stats + unlocked achievements ---
+        # --- Fetch stats + unlocked achievement IDs ---
         trivia_stats = await plugin.get_trivia_stats(uid, gid)
         angle_stats = await plugin.get_angle_stats(uid, gid)
         rps_stats = await plugin.get_rps_stats(uid, gid)
@@ -47,7 +64,7 @@ def register_games_routes(app: FastAPI, plugin: "GamesPlugin") -> None:
         angle_unlocked = {a.achievement_id for a in await plugin.get_angle_achievements(uid, gid)}
         rps_unlocked = {a.achievement_id for a in await plugin.get_rps_achievements(uid, gid)}
 
-        # --- Build section data ---
+        # --- Build sections ---
         sections: list[dict] = []
 
         if game_filter in ("all", "trivia"):
@@ -88,12 +105,11 @@ def _pct(current: int, goal: int) -> int:
     return min(100, int(current / max(goal, 1) * 100))
 
 
-def _build_trivia_items(definitions: dict, unlocked: set, stats: object | None) -> list[dict]:
+def _build_trivia_items(definitions: dict, unlocked: set, stats: Any) -> list[dict]:
     items = []
     for ach_id, data in definitions.items():
         req = data["requirement"]
         req_type, req_value = req["type"], req["value"]
-
         current = 0
         if stats:
             if req_type == "correct_answers":
@@ -108,28 +124,21 @@ def _build_trivia_items(definitions: dict, unlocked: set, stats: object | None) 
                 current = stats.total_points
             elif req_type == "perfect_accuracy":
                 current = 20 if stats.recent_perfect else 0
-
         label = req_type.replace("_", " ").title()
         items.append({
-            "id": ach_id,
-            "name": data["name"],
-            "description": data["description"],
-            "emoji": data["emoji"],
-            "unlocked": ach_id in unlocked,
-            "current": current,
-            "goal": req_value,
-            "pct": _pct(current, req_value),
+            "id": ach_id, "name": data["name"], "description": data["description"],
+            "emoji": data["emoji"], "unlocked": ach_id in unlocked,
+            "current": current, "goal": req_value, "pct": _pct(current, req_value),
             "progress_label": f"{label}: {current:,} / {req_value:,}",
         })
     return items
 
 
-def _build_angle_items(definitions: dict, unlocked: set, stats: object | None) -> list[dict]:
+def _build_angle_items(definitions: dict, unlocked: set, stats: Any) -> list[dict]:
     items = []
     for ach_id, data in definitions.items():
         req = data["requirement"]
         req_type, req_value = req["type"], req["value"]
-
         current = 0
         if stats:
             if req_type == "wins":
@@ -144,28 +153,21 @@ def _build_angle_items(definitions: dict, unlocked: set, stats: object | None) -
                 current = stats.best_win_streak
             elif req_type == "total_points":
                 current = stats.total_points
-
         label = req_type.replace("_", " ").title()
         items.append({
-            "id": ach_id,
-            "name": data["name"],
-            "description": data["description"],
-            "emoji": data["emoji"],
-            "unlocked": ach_id in unlocked,
-            "current": current,
-            "goal": req_value,
-            "pct": _pct(current, req_value),
+            "id": ach_id, "name": data["name"], "description": data["description"],
+            "emoji": data["emoji"], "unlocked": ach_id in unlocked,
+            "current": current, "goal": req_value, "pct": _pct(current, req_value),
             "progress_label": f"{label}: {current:,} / {req_value:,}",
         })
     return items
 
 
-def _build_rps_items(definitions: dict, unlocked: set, stats: object | None) -> list[dict]:
+def _build_rps_items(definitions: dict, unlocked: set, stats: Any) -> list[dict]:
     items = []
     for ach_id, data in definitions.items():
         req = data["requirement"]
         req_type, req_value = req["type"], req["value"]
-
         current = 0
         if stats:
             if req_type == "wins":
@@ -182,17 +184,11 @@ def _build_rps_items(definitions: dict, unlocked: set, stats: object | None) -> 
                 current = stats.scissors_wins
             elif req_type == "draws":
                 current = stats.draws
-
         label = req_type.replace("_", " ").title()
         items.append({
-            "id": ach_id,
-            "name": data["name"],
-            "description": data["description"],
-            "emoji": data["emoji"],
-            "unlocked": ach_id in unlocked,
-            "current": current,
-            "goal": req_value,
-            "pct": _pct(current, req_value),
+            "id": ach_id, "name": data["name"], "description": data["description"],
+            "emoji": data["emoji"], "unlocked": ach_id in unlocked,
+            "current": current, "goal": req_value, "pct": _pct(current, req_value),
             "progress_label": f"{label}: {current:,} / {req_value:,}",
         })
     return items
@@ -256,5 +252,4 @@ def _render_achievements(sections: list[dict], total_unlocked: int, total_all: i
     </div>
 """
         html += "  </div>\n</div>\n"
-
     return html


### PR DESCRIPTION
Remove manual user_id/guild_id text inputs from the panel.
- guild_id is now read from localStorage.selectedGuildId (the sidebar's global guild selector) via hx-vals on HTMX requests
- user_id is read from the auth session on the server side via _get_auth() (same pattern as admin plugin)
- Achievements auto-reload on page load, when the sidebar guild changes (guild-changed event), or when the game filter dropdown changes
- Unauthenticated users see a login prompt; no guild selected shows a hint

https://claude.ai/code/session_015FY8CBbSeb6kHuyJJ5MMfR