### PR TITLE
Fix user ID lookup in achievements route

### DIFF
--- a/plugins/games/web/routes.py
+++ b/plugins/games/web/routes.py
@@ -41,7 +41,7 @@ def register_games_routes(app: FastAPI, plugin: "GamesPlugin") -> None:
 
         current_user = auth.get_current_user(request)
         try:
-            uid = int(current_user["id"])
+            uid = int(current_user["user"]["id"])
         except (KeyError, ValueError, TypeError):
             return HTMLResponse('<p class="ach-msg ach-error">Could not determine your user ID.</p>')
 


### PR DESCRIPTION
get_current_user() returns {"user": {...}, "guilds": [...]} so the Discord user's id is at current_user["user"]["id"], not current_user["id"].

https://claude.ai/code/session_015FY8CBbSeb6kHuyJJ5MMfR