### PR TITLE
Fix empty ephemeral on RPS/angle interactions

### DIFF
--- a/plugins/games/views/angle.py
+++ b/plugins/games/views/angle.py
@@ -140,21 +140,13 @@ class AngleGuessModal(miru.Modal, title="Guess the Angle"):
 
         try:
             if new_view:
-                await self.angle_view.message.edit(
-                    embed=embed,
-                    components=new_view,
-                )
+                await ctx.edit_response(embed=embed, components=new_view)
                 # Re-bind the new view so its button works
                 miru_client = getattr(self.plugin.bot, "miru_client", None)
                 if miru_client:
                     miru_client.start_view(new_view, bind_to=self.angle_view.message)
             else:
-                await self.angle_view.message.edit(
-                    embed=embed,
-                    components=[],
-                )
-            # Acknowledge the modal interaction silently
-            await ctx.respond(flags=hikari.MessageFlag.EPHEMERAL, content="\u200b")
+                await ctx.edit_response(embed=embed, components=[])
         except Exception as exc:
             logger.error("Failed to update angle message: %s", exc)
             await ctx.respond("Guess recorded! Run `/angle` to see your updated board.", flags=hikari.MessageFlag.EPHEMERAL)

--- a/plugins/games/views/rps.py
+++ b/plugins/games/views/rps.py
@@ -84,7 +84,7 @@ class RPSView(miru.View):
                 item.disabled = True
 
         try:
-            await self.message.edit(embed=embed, components=self)
+            await ctx.edit_response(embed=embed, components=self)
         except Exception as exc:
             logger.error("Failed to edit RPS message: %s", exc)
 
@@ -98,7 +98,6 @@ class RPSView(miru.View):
             except Exception as exc:
                 logger.warning("Failed to record RPS result: %s", exc)
 
-        await ctx.respond(flags=hikari.MessageFlag.EPHEMERAL, content="\u200b")
         self.stop()
 
     @miru.button(label="Rock", emoji="🪨", style=hikari.ButtonStyle.SECONDARY, custom_id="rps_rock")


### PR DESCRIPTION
Both handlers were using message.edit() + ctx.respond('\u200b') — the zero-width-space respond() was needed to acknowledge the interaction but produced a blank visible ephemeral popup.

Replace with ctx.edit_response() which sends MESSAGE_UPDATE (type 7) through the interaction itself, editing the original message and acknowledging the interaction in one call with no new message — the same pattern used by every other interactive view in the codebase.

https://claude.ai/code/session_015FY8CBbSeb6kHuyJJ5MMfR